### PR TITLE
Allow Select to quit without selecting an Item with Esc or q

### DIFF
--- a/examples/select_opt.rs
+++ b/examples/select_opt.rs
@@ -1,0 +1,24 @@
+extern crate dialoguer;
+
+use dialoguer::{theme::ColorfulTheme, Select};
+
+fn main() {
+    let selections = &[
+        "Ice Cream",
+        "Vanilla Cupcake",
+        "Chocolate Muffin",
+        "A Pile of sweet, sweet mustard",
+    ];
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Pick your flavor")
+        .default(0)
+        .items(&selections[..])
+        .interact_opt()
+        .unwrap();
+    if let Some(selection) = selection {
+        println!("Enjoy your {}!", selections[selection]);
+    } else {
+        println!("You didn't select anything!");
+    }
+}

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -64,6 +64,7 @@ pub struct Input<'a, T> {
 pub struct PasswordInput<'a> {
     prompt: String,
     theme: &'a Theme,
+    allow_empty_password: bool,
     confirmation_prompt: Option<(String, String)>,
 }
 
@@ -246,6 +247,7 @@ impl<'a> PasswordInput<'a> {
         PasswordInput {
             prompt: "".into(),
             theme: theme,
+            allow_empty_password: false,
             confirmation_prompt: None,
         }
     }
@@ -263,6 +265,14 @@ impl<'a> PasswordInput<'a> {
         mismatch_err: &str,
     ) -> &mut PasswordInput<'a> {
         self.confirmation_prompt = Some((prompt.into(), mismatch_err.into()));
+        self
+    }
+
+    /// Allows/Disables empty password.
+    ///
+    /// By default this setting is set to false (i.e. password is not empty).
+    pub fn allow_empty_password(&mut self, allow_empty_password: bool) -> &mut PasswordInput<'a> {
+        self.allow_empty_password = allow_empty_password;
         self
     }
 
@@ -301,7 +311,7 @@ impl<'a> PasswordInput<'a> {
             render.password_prompt(prompt)?;
             let input = render.term().read_secure_line()?;
             render.add_line();
-            if !input.is_empty() {
+            if !input.is_empty() || self.allow_empty_password {
                 return Ok(input);
             }
         }

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -36,7 +36,7 @@ pub struct Confirmation<'a> {
 /// # fn test() -> Result<(), Box<std::error::Error>> {
 /// use dialoguer::Input;
 ///
-/// let name = Input::new().with_prompt("Your name").interact()?;
+/// let name = Input::<String>::new().with_prompt("Your name").interact()?;
 /// println!("Name: {}", name);
 /// # Ok(()) } fn main() { test().unwrap(); }
 /// ```

--- a/src/select.rs
+++ b/src/select.rs
@@ -86,14 +86,36 @@ impl<'a> Select<'a> {
 
     /// Enables user interaction and returns the result.
     ///
-    /// If the user confirms the result is `true`, `false` otherwise.
+    /// The index of the selected item.
     /// The dialog is rendered on stderr.
     pub fn interact(&self) -> io::Result<usize> {
         self.interact_on(&Term::stderr())
     }
 
+    /// Enables user interaction and returns the result.
+    ///
+    /// The index of the selected item. None if the user
+    /// cancelled with Esc or 'q'.
+    /// The dialog is rendered on stderr.
+    pub fn interact_opt(&self) -> io::Result<Option<usize>> {
+        self._interact_on(&Term::stderr(), true)
+    }
+
     /// Like `interact` but allows a specific terminal to be set.
     pub fn interact_on(&self, term: &Term) -> io::Result<usize> {
+        self._interact_on(term, false)?.ok_or(io::Error::new(
+            io::ErrorKind::Other,
+            "Quit not allowed in this case",
+        ))
+    }
+
+    /// Like `interact` but allows a specific terminal to be set.
+    pub fn interact_on_opt(&self, term: &Term) -> io::Result<Option<usize>> {
+        self._interact_on(term, true)
+    }
+
+    /// Like `interact` but allows a specific terminal to be set.
+    fn _interact_on(&self, term: &Term, allow_quit: bool) -> io::Result<Option<usize>> {
         let mut page = 0;
         let mut capacity = self.items.len();
         if self.paged {
@@ -128,6 +150,14 @@ impl<'a> Select<'a> {
                         sel = 0;
                     } else {
                         sel = (sel as u64 + 1).rem(self.items.len() as u64) as usize;
+                    }
+                }
+                Key::Escape | Key::Char('q') => {
+                    if allow_quit {
+                        if self.clear {
+                            term.clear_last_lines(self.items.len())?;
+                        }
+                        return Ok(None);
                     }
                 }
                 Key::ArrowUp | Key::Char('k') => {
@@ -166,7 +196,7 @@ impl<'a> Select<'a> {
                     if let Some(ref prompt) = self.prompt {
                         render.single_prompt_selection(prompt, &self.items[sel])?;
                     }
-                    return Ok(sel);
+                    return Ok(Some(sel));
                 }
                 _ => {}
             }


### PR DESCRIPTION
Hi,
I want to use Select but allow the user to quit without selecting an Item. I have added interact_opt() and interact_on_opt() methods to Select. These methods return Result<Option<usize>> instead of Result<usize>.