### PR TITLE
Fix Input documentation

### DIFF
--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -36,7 +36,7 @@ pub struct Confirmation<'a> {
 /// # fn test() -> Result<(), Box<std::error::Error>> {
 /// use dialoguer::Input;
 ///
-/// let name = Input::new().with_prompt("Your name").interact()?;
+/// let name = Input::<String>::new().with_prompt("Your name").interact()?;
 /// println!("Name: {}", name);
 /// # Ok(()) } fn main() { test().unwrap(); }
 /// ```


### PR DESCRIPTION
cargo test was failing due to an issue in the documentation for Input.