### PR TITLE
refactor: dry out adding items

### DIFF
--- a/examples/checkboxes.rs
+++ b/examples/checkboxes.rs
@@ -9,9 +9,16 @@ fn main() {
         "Chocolate Muffin",
         "A Pile of sweet, sweet mustard",
     ];
+    let defaults = &[
+        false,
+        false,
+        true,
+        false,
+    ];
     let selections = Checkboxes::with_theme(&ColorfulTheme::default())
         .with_prompt("Pick your food")
         .items(&checkboxes[..])
+        .defaults(&defaults[..])
         .interact()
         .unwrap();
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -62,7 +62,7 @@ impl<'a> Select<'a> {
     }
 
     /// Add a single item to the selector.
-    pub fn item(&mut self, item: &str) -> &mut Select<'a> {
+    pub fn item<T: ToString>(&mut self, item: &T) -> &mut Select<'a> {
         self.items.push(item.to_string());
         self
     }
@@ -70,7 +70,7 @@ impl<'a> Select<'a> {
     /// Adds multiple items to the selector.
     pub fn items<T: ToString>(&mut self, items: &[T]) -> &mut Select<'a> {
         for item in items {
-            self.items.push(item.to_string());
+            self.item(item);
         }
         self
     }
@@ -243,7 +243,7 @@ impl<'a> Checkboxes<'a> {
     }
 
     /// Add a single item to the selector.
-    pub fn item(&mut self, item: &str) -> &mut Checkboxes<'a> {
+    pub fn item<T: ToString>(&mut self, item: &T) -> &mut Checkboxes<'a> {
         self.items.push(item.to_string());
         self
     }
@@ -251,7 +251,7 @@ impl<'a> Checkboxes<'a> {
     /// Adds multiple items to the selector.
     pub fn items<T: ToString>(&mut self, items: &[T]) -> &mut Checkboxes<'a> {
         for item in items {
-            self.items.push(item.to_string());
+            self.item(item);
         }
         self
     }


### PR DESCRIPTION
### Commit about changing `item` and `items`

There is no reason to duplicate the implementation.
Make the batch add just call non-batch version.

One reason for that change is I'd like to introduce pre-selection for
checkboxes. `default` specifies the starting point of user interaction
but there is no API for setting the initial state for `checked`.

### Commit adding defaults to Checkboxes

Mimics the API of items.

I'd really like to introduce a wrapper around the duple of selection item and whether it's selected or not - that way we don't need to keep the two vectors in sync in terms of the lengths and all.

That would change the API though.