### PR TITLE
Fix long multi-line select rendering

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -128,7 +128,7 @@ impl<'a> Select<'a> {
             render.prompt(prompt)?;
         }
         let mut size_vec = Vec::new();
-        for items in self.items.iter().as_slice() {
+        for items in self.items.iter().flat_map(|i| i.split('\n')).collect::<Vec<_>>() {
             let size = &items.len();
             size_vec.push(size.clone());
         }
@@ -287,7 +287,7 @@ impl<'a> Checkboxes<'a> {
             render.prompt(prompt)?;
         }
         let mut size_vec = Vec::new();
-        for items in self.items.iter().as_slice() {
+        for items in self.items.iter().flat_map(|i| i.split('\n')).collect::<Vec<_>>() {
             let size = &items.len();
             size_vec.push(size.clone());
         }


### PR DESCRIPTION
When using a crate like `textwrap` to wrap ridiculously long lines to use with a select prompt, the rendering mechanism would still clear a few lines too much.

Therefore: while counting the characters per line, take newlines into consideration and make it a separate line.