### PR TITLE
Fix right arrow behavior on paged select

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -208,7 +208,7 @@ impl<'a> Select<'a> {
                         if page == pages - 1 {
                             page = 0;
                         } else {
-                            page -= 1;
+                            page += 1;
                         }
                         sel = page * capacity;
                     }


### PR DESCRIPTION
When pressing the right arrow key in a paged select the code goes to the previous page instead of the next one. In addition to being wrong, this also panics because of integer underflow when on the first page. This PR fixes this bug.