### PR TITLE
Add repository to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 keywords = ["cli", "menu", "prompt"]
 license = "MIT"
 homepage = "https://github.com/mitsuhiko/dialoguer"
+repository = "https://github.com/mitsuhiko/dialoguer"
 documentation = "https://docs.rs/dialoguer"
 readme = "README.md"
 


### PR DESCRIPTION
This adds the repository field to the `Cargo.toml` file.