### PR TITLE
Support for buffered terminals

### DIFF
--- a/examples/buffered.rs
+++ b/examples/buffered.rs
@@ -1,0 +1,53 @@
+extern crate console;
+extern crate dialoguer;
+
+use console::Term;
+use dialoguer::{
+    theme::ColorfulTheme, Checkboxes, Confirmation, Input, OrderList, PasswordInput, Select,
+};
+
+fn main() {
+    let items = &[
+        "Ice Cream",
+        "Vanilla Cupcake",
+        "Chocolate Muffin",
+        "A Pile of sweet, sweet mustard",
+    ];
+    let term = Term::buffered_stderr();
+    let theme = ColorfulTheme::default();
+
+    println!("All the following controls are run in a buffered terminal");
+    Confirmation::with_theme(&theme)
+        .with_text("Do you want to continue?")
+        .interact_on(&term)
+        .unwrap();
+
+    let _: String = Input::with_theme(&theme)
+        .with_prompt("Your name")
+        .interact_on(&term)
+        .unwrap();
+
+    PasswordInput::with_theme(&theme)
+        .with_prompt("Your password")
+        .with_confirmation("Confirm", "Passwords do not match")
+        .interact_on(&term)
+        .unwrap();
+
+    Select::with_theme(&theme)
+        .with_prompt("Pick an item")
+        .items(items)
+        .interact_on(&term)
+        .unwrap();
+
+    Checkboxes::with_theme(&theme)
+        .with_prompt("Pick some items")
+        .items(items)
+        .interact_on(&term)
+        .unwrap();
+
+    OrderList::with_theme(&theme)
+        .with_prompt("Order these items")
+        .items(items)
+        .interact_on(&term)
+        .unwrap();
+}

--- a/src/select.rs
+++ b/src/select.rs
@@ -169,6 +169,7 @@ impl<'a> Select<'a> {
                     },
                 )?;
             }
+            term.flush()?;
             match term.read_key()? {
                 Key::ArrowDown | Key::Char('j') => {
                     if sel == !0 {
@@ -181,6 +182,7 @@ impl<'a> Select<'a> {
                     if allow_quit {
                         if self.clear {
                             term.clear_last_lines(self.items.len())?;
+                            term.flush()?;
                         }
                         return Ok(None);
                     }
@@ -221,6 +223,7 @@ impl<'a> Select<'a> {
                     if let Some(ref prompt) = self.prompt {
                         render.single_prompt_selection(prompt, &self.items[sel])?;
                     }
+                    term.flush()?;
                     return Ok(Some(sel));
                 }
                 _ => {}
@@ -370,6 +373,7 @@ impl<'a> Checkboxes<'a> {
                     },
                 )?;
             }
+            term.flush()?;
             match term.read_key()? {
                 Key::ArrowDown | Key::Char('j') => {
                     if sel == !0 {
@@ -416,6 +420,7 @@ impl<'a> Checkboxes<'a> {
                     if let Some(ref prompt) = self.prompt {
                         render.multi_prompt_selection(prompt, &[][..])?;
                     }
+                    term.flush()?;
                     return Ok(
                         self.defaults.clone()
                             .into_iter()
@@ -442,6 +447,7 @@ impl<'a> Checkboxes<'a> {
                             .collect();
                         render.multi_prompt_selection(prompt, &selections[..])?;
                     }
+                    term.flush()?;
                     return Ok(checked
                         .into_iter()
                         .enumerate()
@@ -561,6 +567,7 @@ impl<'a> OrderList<'a> {
                     },
                 )?;
             }
+            term.flush()?;
             match term.read_key()? {
                 Key::ArrowDown | Key::Char('j') => {
                     let old_sel = sel;
@@ -648,6 +655,7 @@ impl<'a> OrderList<'a> {
                             .collect();
                         render.multi_prompt_selection(prompt, &list[..])?;
                     }
+                    term.flush()?;
                     return Ok(order);
                 }
                 _ => {}


### PR DESCRIPTION
Right now, buffered terminals (e.g. `Term::buffered_stderr()`, etc.) cannot be used with any of the interactive controls, as they never call `Term::flush`. Using a buffered terminal reduces the amount of flickering when scrolling through longer `Select` or `Checkboxes` lists. This PR adds the necessary flush calls and an example using a buffered stderr terminal.