### PR TITLE
Validate after parsing

### DIFF
--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -276,14 +276,14 @@ where
                 }
             }
             render.clear()?;
-            if let Some(ref validator) = self.validator {
-                if let Some(err) = validator(&input) {
-                    render.error(&err)?;
-                    continue;
-                }
-            }
             match input.parse::<T>() {
                 Ok(value) => {
+                    if let Some(ref validator) = self.validator {
+                        if let Some(err) = validator(&input) {
+                            render.error(&err)?;
+                            continue;
+                        }
+                    }
                     render.single_prompt_selection(&self.prompt, &input)?;
                     return Ok(value);
                 }


### PR DESCRIPTION
Simply swapped around parsing and validating. If it successfully parses, then validate. Since if parsing fails, then it doesn't matter if it was validated.

Example:

```rust
Input::<i32>::new()
    .validate_with(|_input: &str| -> Result<(), &str> {
        println!("Validate");
        Ok(())
    })
    .interact()
    .unwrap();
```

Before if you entered `foo`, then it would display:

```
Validate
error: invalid digit found in string
```