### PR TITLE
Fixed prompt formatting

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -36,6 +36,7 @@ pub trait Theme {
         default: Option<&str>,
     ) -> fmt::Result {
         match default {
+            Some(default) if prompt.is_empty() => write!(f, "[{}]: ", default),
             Some(default) => write!(f, "{} [{}]: ", prompt, default),
             None => write!(f, "{}: ", prompt),
         }
@@ -53,11 +54,13 @@ pub trait Theme {
         prompt: &str,
         default: Option<bool>,
     ) -> fmt::Result {
-        write!(f, "{}", &prompt)?;
+        if !prompt.is_empty() {
+            write!(f, "{} ", &prompt)?;
+        }
         match default {
             None => {}
-            Some(true) => write!(f, " [Y/n] ")?,
-            Some(false) => write!(f, " [y/N] ")?,
+            Some(true) => write!(f, "[Y/n] ")?,
+            Some(false) => write!(f, "[y/N] ")?,
         }
         Ok(())
     }
@@ -69,7 +72,11 @@ pub trait Theme {
         prompt: &str,
         selection: bool,
     ) -> fmt::Result {
-        write!(f, "{} {}", &prompt, if selection { "yes" } else { "no" })
+        if prompt.is_empty() {
+            write!(f, "{}", if selection { "yes" } else { "no" })
+        } else {
+            write!(f, "{} {}", &prompt, if selection { "yes" } else { "no" })
+        }
     }
 
     /// Renders a prompt and a single selection made.


### PR DESCRIPTION
This pull request fixes a missing whitespace after the text:

```rust
// Before, this did not add a whitespace after the text. Rendering as "text":
Confirmation::new().with_text("text").show_default(false).interact()

// While these, before rendered as "text [Y/n] ":
Confirmation::new().with_text("text").show_default(true).interact().unwrap();
Confirmation::new().with_text("text").interact().unwrap();
```

It also removes a whitespace before, if there is no text:

```rust
// After interaction, these would before render as e.g. " yes"
Confirmation::new().interact().unwrap();
Confirmation::new().show_default(false).interact().unwrap();
```

This also fixing The same issue is fixed for `Input`:

```rust
// Before, this would render as ` [default]: `
Input::<String>::new().default("default".into()).interact().unwrap();
```

I also added some general checks, for whether the `prompt` or `text` is empty, and then not rendering it, which would similarly add the single whitespace beforehand.

```rust
// Before, this would render as ` [default]: `
Input::<String>::new().with_prompt("").default("default".into()).interact().unwrap();
```

*Though calling `.with_prompt("")` would ofc be pointless.*

Note I only checked `Theme`, so there might be similar issues in themes implementing `Theme`. I'll check later, if I have time.