### PR TITLE
Updated example for Confirm

### DIFF
--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -12,7 +12,7 @@ use console::Term;
 /// # fn test() -> Result<(), Box<std::error::Error>> {
 /// use dialoguer::Confirm;
 ///
-/// if Confirm::new().with_text("Do you want to continue?").interact()? {
+/// if Confirm::new().with_prompt("Do you want to continue?").interact()? {
 ///     println!("Looks like you want to continue");
 /// } else {
 ///     println!("nevermind then :(");


### PR DESCRIPTION
`Confirm::with_text` was deprecated. The example should no longer use it.