### PR TITLE
Fix divide by zero when capacity is 0

### DIFF
--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -132,7 +132,12 @@ impl<'a> MultiSelect<'a> {
             self.items.len()
         };
 
-        let pages = (self.items.len() / capacity) + 1;
+        let pages = if capacity == 0 {
+            return Ok(vec![]);
+        } else {
+            (self.items.len() / capacity) + 1
+        };
+
         let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = 0;
 


### PR DESCRIPTION
Not 100% sure what the behaviour should be in this case,

We could set pages to 0 and show nothing to the user (which is confusing)

or we could return an empty Vec  immediately (which is also confusing but slightly less so I think)