### PR TITLE
Add option to Confirm that forces user to enter 'y' or 'n' to continue

### DIFF
--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -3,11 +3,10 @@ extern crate dialoguer;
 use dialoguer::Confirm;
 
 fn main() {
-    println!("with confirm");
+    println!("disable default");
     if Confirm::new()
         .with_prompt("continue?")
-        .confirm(true)
-        .wait_for_newline(true)
+        .disable_default(true)
         .interact()
         .unwrap()
     {
@@ -18,10 +17,9 @@ fn main() {
 
     println!();
 
-    println!("without confirm");
+    println!("enable default");
     if Confirm::new()
         .with_prompt("continue?")
-        .wait_for_newline(true)
         .interact()
         .unwrap()
     {

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -1,0 +1,32 @@
+extern crate dialoguer;
+
+use dialoguer::Confirm;
+
+fn main() {
+    println!("with confirm");
+    if Confirm::new()
+        .with_prompt("continue?")
+        .confirm(true)
+        .wait_for_newline(true)
+        .interact()
+        .unwrap()
+    {
+        println!("continuing");
+    } else {
+        println!("exiting");
+    }
+
+    println!();
+
+    println!("without confirm");
+    if Confirm::new()
+        .with_prompt("continue?")
+        .wait_for_newline(true)
+        .interact()
+        .unwrap()
+    {
+        println!("continuing");
+    } else {
+        println!("exiting");
+    }
+}

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -23,6 +23,7 @@ pub struct Confirm<'a> {
     prompt: String,
     default: bool,
     show_default: bool,
+    confirm: bool,
     wait_for_newline: bool,
     theme: &'a dyn Theme,
 }
@@ -60,6 +61,7 @@ impl<'a> Confirm<'a> {
             prompt: "".into(),
             default: true,
             show_default: true,
+            confirm: false,
             wait_for_newline: false,
             theme,
         }
@@ -106,6 +108,16 @@ impl<'a> Confirm<'a> {
     /// in uppercase. The default is selected on enter.
     pub fn show_default(&mut self, val: bool) -> &mut Confirm<'a> {
         self.show_default = val;
+        self
+    }
+
+    /// Select whether the user must explicitly confirm their selection.
+    ///
+    /// When `false` (default), the user can input a newline to select the default.
+    ///
+    /// When `true`, the user must input a letter - a newline will do nothing.
+    pub fn confirm(&mut self, val: bool) -> &mut Confirm<'a> {
+        self.confirm = val;
         self
     }
 
@@ -156,7 +168,7 @@ impl<'a> Confirm<'a> {
                 let rv = match &*input_buf.trim_end().to_lowercase() {
                     "y" | "yes" => true,
                     "n" | "no" => false,
-                    "" => self.default,
+                    "" if !self.confirm => self.default,
                     _ => {
                         // On invalid input re-render the user prompt.
                         render.confirm_prompt(&self.prompt, default)?;
@@ -178,7 +190,7 @@ impl<'a> Confirm<'a> {
                 let rv = match input {
                     'y' | 'Y' => true,
                     'n' | 'N' => false,
-                    '\n' | '\r' => self.default,
+                    '\n' | '\r' if !self.confirm => self.default,
                     _ => {
                         continue;
                     }

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -23,7 +23,7 @@ pub struct Confirm<'a> {
     prompt: String,
     default: bool,
     show_default: bool,
-    confirm: bool,
+    disable_default: bool,
     wait_for_newline: bool,
     theme: &'a dyn Theme,
 }
@@ -61,7 +61,7 @@ impl<'a> Confirm<'a> {
             prompt: "".into(),
             default: true,
             show_default: true,
-            confirm: false,
+            disable_default: false,
             wait_for_newline: false,
             theme,
         }
@@ -116,8 +116,8 @@ impl<'a> Confirm<'a> {
     /// When `false` (default), the user can input a newline to select the default.
     ///
     /// When `true`, the user must input a letter - a newline will do nothing.
-    pub fn confirm(&mut self, val: bool) -> &mut Confirm<'a> {
-        self.confirm = val;
+    pub fn disable_default(&mut self, val: bool) -> &mut Confirm<'a> {
+        self.disable_default = val;
         self
     }
 
@@ -168,7 +168,7 @@ impl<'a> Confirm<'a> {
                 let rv = match &*input_buf.trim_end().to_lowercase() {
                     "y" | "yes" => true,
                     "n" | "no" => false,
-                    "" if !self.confirm => self.default,
+                    "" if !self.disable_default => self.default,
                     _ => {
                         // On invalid input re-render the user prompt.
                         render.confirm_prompt(&self.prompt, default)?;
@@ -190,7 +190,7 @@ impl<'a> Confirm<'a> {
                 let rv = match input {
                     'y' | 'Y' => true,
                     'n' | 'N' => false,
-                    '\n' | '\r' if !self.confirm => self.default,
+                    '\n' | '\r' if !self.disable_default => self.default,
                     _ => {
                         continue;
                     }


### PR DESCRIPTION
Fixes #64