### PR TITLE
Remove 'static restriction on Input<T> validate_with() and fix tests

### DIFF
--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -9,7 +9,7 @@ use console::Term;
 /// ## Example usage
 ///
 /// ```rust,no_run
-/// # fn test() -> Result<(), Box<std::error::Error>> {
+/// # fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// use dialoguer::Confirm;
 ///
 /// if Confirm::new().with_prompt("Do you want to continue?").interact()? {
@@ -41,14 +41,14 @@ impl<'a> Confirm<'a> {
     }
 
     /// Creates a confirm prompt with a specific theme.
-    /// 
+    ///
     /// ## Examples
     /// ```rust,no_run
     /// use dialoguer::{
     ///     Confirm,
     ///     theme::ColorfulTheme
     /// };
-    /// 
+    ///
     /// # fn main() -> std::io::Result<()> {
     /// let proceed = Confirm::with_theme(&ColorfulTheme::default())
     ///     .with_prompt("Do you wish to continue?")
@@ -94,7 +94,7 @@ impl<'a> Confirm<'a> {
     }
     /// Overrides the default output if user pushes enter key without inputing any character.
     /// Character corresponding to the default choice (e.g `Y` if default is `true`) will be uppercased in the displayed prompt.
-    /// 
+    ///
     /// The default output is true.
     pub fn default(&mut self, val: bool) -> &mut Confirm<'a> {
         self.default = val;
@@ -125,20 +125,20 @@ impl<'a> Confirm<'a> {
     ///
     /// If the user confirms the result is `true`, `false` if declines or default (configured in [default](#method.default)) if pushes enter.
     /// Otherwise function discards input waiting for valid one.
-    /// 
+    ///
     /// The dialog is rendered on stderr.
     pub fn interact(&self) -> io::Result<bool> {
         self.interact_on(&Term::stderr())
     }
 
     /// Like [interact](#method.interact) but allows a specific terminal to be set.
-    /// 
-    /// ## Examples 
-    /// 
-    /// ```rust,nor_run
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
     /// use dialoguer::Confirm;
     /// use console::Term;
-    /// 
+    ///
     /// # fn main() -> std::io::Result<()> {
     /// let proceed = Confirm::new()
     ///     .with_prompt("Do you wish to continue?")

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -5,15 +5,18 @@ use crate::theme::{SimpleTheme, TermThemeRenderer, Theme};
 use console::{Key, Term};
 
 /// Renders a multi select prompt.
-/// 
+///
 /// ## Example usage
 /// ```rust,no_run
+/// # fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// use dialoguer::MultiSelect;
-/// 
-/// let items = vec![("Option 1", true), ("Option 2", false)];
+///
+/// let items = vec!["Option 1", "Option 2"];
 /// let chosen : Vec<usize> = MultiSelect::new()
 ///     .items(&items)
 ///     .interact()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct MultiSelect<'a> {
     defaults: Vec<bool>,

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -5,18 +5,21 @@ use crate::theme::{SimpleTheme, TermThemeRenderer, Theme};
 use console::{Key, Term};
 
 /// Renders a sort prompt.
-/// 
+///
 /// Returns list of indices in original items list sorted according to user input.
-/// 
+///
 /// ## Example usage
 /// ```rust,no_run
 /// use dialoguer::Sort;
 ///
+/// # fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// let items_to_order = vec!["Item 1", "Item 2", "Item 3"];
 /// let ordered = Sort::new()
 ///     .with_prompt("Order the items")
 ///     .items(&items_to_order)
 ///     .interact()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct Sort<'a> {
     items: Vec<String>,


### PR DESCRIPTION
See https://github.com/jamesmcm/vopono/issues/19 for how this caused issues previously.

Also fixed current tests to run for current codebase.

Note #43 means that the validators now need to take `&String` not `&str` (since the type signature dictates `&T`). This is a bit painful.

This is because for the Input<T>, T is the owned type i.e. String, so then the closure (on `&T`) must accept &String and cannot accept &str. I tried to work around this with AsRef but it won't work unless we change the T to be the base type i.e. &str and then use ToOwned to make it return the owned type (we could even use Cow). But this is a lot of work and would change all instantiations of `Input<T>`.