### PR TITLE
Fix clippy issues and remove extern crate statements from examples

### DIFF
--- a/examples/buffered.rs
+++ b/examples/buffered.rs
@@ -1,6 +1,3 @@
-extern crate console;
-extern crate dialoguer;
-
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, MultiSelect, Password, Select, Sort};
 

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use dialoguer::Confirm;
 
 fn main() {
@@ -18,11 +16,7 @@ fn main() {
     println!();
 
     println!("enable default");
-    if Confirm::new()
-        .with_prompt("continue?")
-        .interact()
-        .unwrap()
-    {
+    if Confirm::new().with_prompt("continue?").interact().unwrap() {
         println!("continuing");
     } else {
         println!("exiting");

--- a/examples/continue.rs
+++ b/examples/continue.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use dialoguer::{Confirm, Input};
 
 fn main() {
@@ -14,6 +12,9 @@ fn main() {
         return;
     }
 
-    let input: String = Input::new().with_prompt("Your name").interact_text().unwrap();
+    let input: String = Input::new()
+        .with_prompt("Your name")
+        .interact_text()
+        .unwrap();
     println!("Hello {}!", input);
 }

--- a/examples/edit.rs
+++ b/examples/edit.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use dialoguer::Editor;
 
 fn main() {

--- a/examples/multi_select.rs
+++ b/examples/multi_select.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use dialoguer::{theme::ColorfulTheme, MultiSelect};
 
 fn main() {

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use dialoguer::{theme::ColorfulTheme, Password};
 
 fn main() {

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use dialoguer::{theme::ColorfulTheme, Select};
 
 fn main() {

--- a/examples/select_opt.rs
+++ b/examples/select_opt.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use dialoguer::{theme::ColorfulTheme, Select};
 
 fn main() {

--- a/examples/sort.rs
+++ b/examples/sort.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use dialoguer::{theme::ColorfulTheme, Sort};
 
 fn main() {

--- a/examples/validate_input.rs
+++ b/examples/validate_input.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use dialoguer::Input;
 
 fn main() {

--- a/examples/wizard.rs
+++ b/examples/wizard.rs
@@ -1,6 +1,3 @@
-extern crate console;
-extern crate dialoguer;
-
 use std::error::Error;
 use std::net::IpAddr;
 

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -182,7 +182,7 @@ where
             render.input_prompt(
                 &self.prompt,
                 if self.show_default {
-                    default_string.as_ref().map(|x| x.as_str())
+                    default_string.as_deref()
                 } else {
                     None
                 },
@@ -297,7 +297,7 @@ where
             render.input_prompt(
                 &self.prompt,
                 if self.show_default {
-                    default_string.as_ref().map(|x| x.as_str())
+                    default_string.as_deref()
                 } else {
                     None
                 },

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -157,7 +157,7 @@ impl<'a> MultiSelect<'a> {
             .collect::<Vec<_>>()
         {
             let size = &items.len();
-            size_vec.push(size.clone());
+            size_vec.push(*size);
         }
 
         let mut checked: Vec<bool> = self.defaults.clone();

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -5,31 +5,31 @@ use crate::theme::{SimpleTheme, TermThemeRenderer, Theme};
 use console::{Key, Term};
 
 /// Renders a select prompt.
-/// 
-/// User can select from one or more options. 
+///
+/// User can select from one or more options.
 /// Interaction returns index of an item selected in the order they appear in `item` invocation or `items` slice.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```rust,no_run
 /// use dialoguer::{
 ///     Select,
 ///     theme::ColorfulTheme
 /// };
 /// use console::Term;
-/// 
+///
 /// fn main() -> std::io::Result<()> {
 ///     let items = vec!["Item 1", "item 2"];
 ///     let selection = Select::with_theme(&ColorfulTheme::default())
 ///         .items(&items)
 ///         .default(0)
 ///         .interact_on_opt(&Term::stderr())?;
-/// 
+///
 ///     match selection {
 ///         Some(index) => println!("User selected item : {}", items[index]),
 ///         None => println!("User did not select anything")
 ///     }
-/// 
+///
 ///     Ok(())
 /// }
 /// ```
@@ -68,7 +68,7 @@ impl<'a> Select<'a> {
     ///         .item("Option A")
     ///         .item("Option B")
     ///         .interact()?;
-    /// 
+    ///
     ///     Ok(())
     /// }
     /// ```
@@ -84,7 +84,7 @@ impl<'a> Select<'a> {
     }
 
     /// Enables or disables paging
-    /// 
+    ///
     /// Paging is disabled by default
     pub fn paged(&mut self, val: bool) -> &mut Select<'a> {
         self.paged = val;
@@ -100,7 +100,7 @@ impl<'a> Select<'a> {
     }
 
     /// Sets initial selected element when select menu is rendered
-    /// 
+    ///
     /// Element is indicated by the index at which it appears in `item` method invocation or `items` slice.
     pub fn default(&mut self, val: usize) -> &mut Select<'a> {
         self.default = val;
@@ -108,7 +108,7 @@ impl<'a> Select<'a> {
     }
 
     /// Add a single item to the selector.
-    /// 
+    ///
     /// ## Examples
     /// ```rust,no_run
     /// use dialoguer::Select;
@@ -128,7 +128,7 @@ impl<'a> Select<'a> {
     }
 
     /// Adds multiple items to the selector.
-    /// 
+    ///
     /// ## Examples
     /// ```rust,no_run
     /// use dialoguer::Select;
@@ -155,18 +155,18 @@ impl<'a> Select<'a> {
     ///
     /// When a prompt is set the system also prints out a confirmation after
     /// the selection.
-    /// 
+    ///
     /// ## Examples
     /// ```rust,no_run
     /// use dialoguer::Select;
-    /// 
+    ///
     /// fn main() -> std::io::Result<()> {
     ///     let selection = Select::new()
     ///         .with_prompt("Which option do you prefer?")
     ///         .item("Option A")
     ///         .item("Option B")
     ///         .interact()?;
-    /// 
+    ///
     ///     Ok(())
     /// }
     /// ```
@@ -186,7 +186,7 @@ impl<'a> Select<'a> {
 
     /// Enables user interaction and returns the result.
     ///
-    /// This method is similar to [interact_on_opt](#method.interact_on_opt) except for the fact that it does not allow selection of the terminal. 
+    /// This method is similar to [interact_on_opt](#method.interact_on_opt) except for the fact that it does not allow selection of the terminal.
     /// The dialog is rendered on stderr.
     /// Result contains `Some(index)` if user selected one of items or `None` if user cancelled with 'Esc' or 'q'.
     pub fn interact_opt(&self) -> io::Result<Option<usize>> {
@@ -194,46 +194,46 @@ impl<'a> Select<'a> {
     }
 
     /// Like [interact](#method.interact) but allows a specific terminal to be set.
-    /// 
+    ///
     /// ## Examples
     ///```rust,no_run
     /// use dialoguer::Select;
     /// use console::Term;
-    /// 
+    ///
     /// fn main() -> std::io::Result<()> {
     ///     let selection = Select::new()
     ///         .item("Option A")
     ///         .item("Option B")
     ///         .interact_on(&Term::stderr())?;
-    /// 
+    ///
     ///     println!("User selected option at index {}", selection);
-    /// 
+    ///
     ///     Ok(())
     /// }
-    ///``` 
+    ///```
     pub fn interact_on(&self, term: &Term) -> io::Result<usize> {
         self._interact_on(term, false)?
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Quit not allowed in this case"))
     }
 
     /// Like [interact_opt](#method.interact_opt) but allows a specific terminal to be set.
-    /// 
+    ///
     /// ## Examples
     /// ```rust,no_run
     /// use dialoguer::Select;
     /// use console::Term;
-    /// 
+    ///
     /// fn main() -> std::io::Result<()> {
     ///     let selection = Select::new()
     ///         .item("Option A")
     ///         .item("Option B")
     ///         .interact_on_opt(&Term::stdout())?;
-    /// 
+    ///
     ///     match selection {
     ///         Some(position) => println!("User selected option at index {}", position),
     ///         None => println!("User did not select anything")
     ///     }
-    /// 
+    ///
     ///     Ok(())
     /// }
     /// ```

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -269,7 +269,7 @@ impl<'a> Select<'a> {
             .collect::<Vec<_>>()
         {
             let size = &items.len();
-            size_vec.push(size.clone());
+            size_vec.push(*size);
         }
 
         loop {

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -119,7 +119,7 @@ impl<'a> Sort<'a> {
 
         for items in self.items.iter().as_slice() {
             let size = &items.len();
-            size_vec.push(size.clone());
+            size_vec.push(*size);
         }
 
         let mut order: Vec<_> = (0..self.items.len()).collect();


### PR DESCRIPTION
Make examples use Rust 2018 syntax :slightly_smiling_face: 