### PR TITLE
Add command-line-interface category to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
 	"Pavan Kumar Sunkara <pavan.sss1991@gmail.com>"
 ]
 keywords = ["cli", "menu", "prompt"]
+categories = ["command-line-interface"]
 license = "MIT"
 homepage = "https://github.com/mitsuhiko/dialoguer"
 repository = "https://github.com/mitsuhiko/dialoguer"


### PR DESCRIPTION
This patch adds the command-line-interface category [0] to Cargo.toml
for better discoverability on crates.io and lib.rs.

[0] https://crates.io/categories/command-line-interface