### PR TITLE
fix args in vim -N -u NONE

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -100,7 +100,13 @@ impl Editor {
         f.flush()?;
         let ts = fs::metadata(f.path())?.modified()?;
 
-        let rv = process::Command::new(&self.editor)
+        let s: String = self.editor.clone().into_string().unwrap();
+        let mut iterator = s.split(" ");
+        let cmd = iterator.next().unwrap();
+        let args: Vec<&str> = iterator.collect();
+
+        let rv = process::Command::new(cmd)
+            .args(args)
             .arg(f.path())
             .spawn()?
             .wait()?;


### PR DESCRIPTION
It's an experiment pr to fix https://github.com/mitsuhiko/dialoguer/issues/87