### PR TITLE
Allow FnMut for validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.8.0
+
+### Enhancements
+
+* `Input::validate_with` can take a `FnMut` (allowing multiple references)
+
+### Breaking
+
+* `Input::interact*` methods take `&mut self` instead of `&self`
+
 ## 0.7.0
 
 ### Enhancements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dialoguer"
 description = "A command line prompting library."
-version = "0.8.0"
+version = "0.7.1"
 edition = "2018"
 authors = [
 	"Armin Ronacher <armin.ronacher@active-4.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dialoguer"
 description = "A command line prompting library."
-version = "0.7.1"
+version = "0.8.0"
 edition = "2018"
 authors = [
 	"Armin Ronacher <armin.ronacher@active-4.com>",

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -10,11 +10,15 @@ fn main() {
 
     let mail: String = Input::with_theme(&ColorfulTheme::default())
         .with_prompt("Your email")
-        .validate_with(|input: &String| -> Result<(), &str> {
-            if input.contains('@') {
-                Ok(())
-            } else {
-                Err("This is not a mail address")
+        .validate_with({
+            let mut force = None;
+            move |input: &String| -> Result<(), &str> {
+                if input.contains('@') || force.as_ref().map_or(false, |old| old == input) {
+                    Ok(())
+                } else {
+                    force = Some(input.clone());
+                    Err("This is not a mail address; type the same value again to force use")
+                }
             }
         })
         .interact_text()

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -12,13 +12,13 @@ pub trait Validator<T> {
     ///
     /// If this produces `Ok(())` then the value is used and parsed, if
     /// an error is returned validation fails with that error.
-    fn validate(&self, input: &T) -> Result<(), Self::Err>;
+    fn validate(&mut self, input: &T) -> Result<(), Self::Err>;
 }
 
-impl<T, F: Fn(&T) -> Result<(), E>, E: Debug + Display> Validator<T> for F {
+impl<T, F: FnMut(&T) -> Result<(), E>, E: Debug + Display> Validator<T> for F {
     type Err = E;
 
-    fn validate(&self, input: &T) -> Result<(), Self::Err> {
+    fn validate(&mut self, input: &T) -> Result<(), Self::Err> {
         self(input)
     }
 }


### PR DESCRIPTION
This allows mutable closures for validation, allowing stateful
validators.

This breaks BC. Input::interact*() now take &mut self instead of &self.
However, this shall not break most usres,
since (I think) users usually use Input in chained syntax
or call one of the &mut methods (like with_prompt) separately,
which would require a `let mut` anyway.