### PR TITLE
Allow confirm with no choice

### DIFF
--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -58,6 +58,7 @@ fn main() {
 
     match Confirm::with_theme(&ColorfulTheme::default())
         .with_prompt("Do you really really really really really want to continue?")
+        .default(true)
         .wait_for_newline(true)
         .interact_opt()
         .unwrap()

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -45,4 +45,14 @@ fn main() {
     } else {
         println!("nevermind then :(");
     }
+
+    match Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Do you really really really really want to continue?")
+        .interact_opt()
+        .unwrap()
+    {
+        Some(true) => println!("Looks like you want to continue"),
+        Some(false) => println!("nevermind then :("),
+        None => println!("Ok, we can start over later"),
+    }
 }

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -55,4 +55,15 @@ fn main() {
         Some(false) => println!("nevermind then :("),
         None => println!("Ok, we can start over later"),
     }
+
+    match Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Do you really really really really really want to continue?")
+        .wait_for_newline(true)
+        .interact_opt()
+        .unwrap()
+    {
+        Some(true) => println!("Looks like you want to continue"),
+        Some(false) => println!("nevermind then :("),
+        None => println!("Ok, we can start over later"),
+    }
 }

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -205,7 +205,9 @@ impl<'a> Confirm<'a> {
                         value = Some(false);
                     }
                     Key::Enter => {
-                        value = value.or(self.default);
+                        if !allow_quit {
+                            value = value.or(self.default);
+                        }
 
                         if value.is_some() || allow_quit {
                             rv = value;

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -137,6 +137,10 @@ impl<'a> Confirm<'a> {
     /// # }
     /// ```
     pub fn interact_on(&self, term: &Term) -> io::Result<bool> {
+        self._interact_on(term, false)
+    }
+
+    fn _interact_on(&self, term: &Term, allow_quit: bool) -> io::Result<bool> {
         let mut render = TermThemeRenderer::new(term, self.theme);
 
         let default_if_show = if self.show_default {

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -182,6 +182,9 @@ impl<'a> Confirm<'a> {
                             continue;
                         }
                     }
+                    Key::Escape | Key::Char('q') if allow_quit => {
+                        value = None;
+                    }
                     _ => {
                         continue;
                     }
@@ -199,6 +202,7 @@ impl<'a> Confirm<'a> {
                     Key::Char('y') | Key::Char('Y') => Some(true),
                     Key::Char('n') | Key::Char('N') => Some(false),
                     Key::Enter if self.default.is_some() => Some(self.default.unwrap()),
+                    Key::Escape | Key::Char('q') if allow_quit => None,
                     _ => {
                         continue;
                     }

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -121,6 +121,15 @@ impl<'a> Confirm<'a> {
         self.interact_on(&Term::stderr())
     }
 
+    /// Enables user interaction and returns the result.
+    ///
+    /// This method is similar to [interact_on_opt](#method.interact_on_opt) except for the fact that it does not allow selection of the terminal.
+    /// The dialog is rendered on stderr.
+    /// Result contains `Some(bool)` if user answered "yes" or "no" or `None` if user cancelled with 'Esc' or 'q'.
+    pub fn interact_opt(&self) -> io::Result<Option<bool>> {
+        self.interact_on_opt(&Term::stderr())
+    }
+
     /// Like [interact](#method.interact) but allows a specific terminal to be set.
     ///
     /// ## Examples
@@ -139,6 +148,29 @@ impl<'a> Confirm<'a> {
     pub fn interact_on(&self, term: &Term) -> io::Result<bool> {
         self._interact_on(term, false)?
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Quit not allowed in this case"))
+    }
+
+    /// Like [interact_opt](#method.interact_opt) but allows a specific terminal to be set.
+    ///
+    /// ## Examples
+    /// ```rust,no_run
+    /// use dialoguer::Confirm;
+    /// use console::Term;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let confirmation = Confirm::new()
+    ///         .interact_on_opt(&Term::stdout())?;
+    ///
+    ///     match confirmation {
+    ///         Some(answer) => println!("User answered {}", if answer { "yes" } else { "no " }),
+    ///         None => println!("User did not answer")
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn interact_on_opt(&self, term: &Term) -> io::Result<Option<bool>> {
+        self._interact_on(term, true)
     }
 
     fn _interact_on(&self, term: &Term, allow_quit: bool) -> io::Result<Option<bool>> {

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -207,12 +207,11 @@ impl<'a> Confirm<'a> {
                     Key::Enter => {
                         value = value.or(self.default);
 
-                        if let Some(val) = value {
-                            rv = Some(val);
+                        if value.is_some() || allow_quit {
+                            rv = value;
                             break;
-                        } else {
-                            continue;
                         }
+                        continue;
                     }
                     Key::Escape | Key::Char('q') if allow_quit => {
                         value = None;

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use crate::theme::{SimpleTheme, TermThemeRenderer, Theme};
 
-use console::Term;
+use console::{Key, Term};
 
 /// Renders a confirm prompt.
 ///
@@ -162,16 +162,16 @@ impl<'a> Confirm<'a> {
             let mut value = default_if_show;
 
             loop {
-                let input = term.read_char()?;
+                let input = term.read_key()?;
 
                 match input {
-                    'y' | 'Y' => {
+                    Key::Char('y') | Key::Char('Y') => {
                         value = Some(true);
                     }
-                    'n' | 'N' => {
+                    Key::Char('n') | Key::Char('N') => {
                         value = Some(false);
                     }
-                    '\n' | '\r' => {
+                    Key::Enter => {
                         value = value.or(self.default);
 
                         if let Some(val) = value {
@@ -193,11 +193,11 @@ impl<'a> Confirm<'a> {
             // Default behavior: matches continuously on every keystroke,
             // and does not wait for user to hit the Enter key.
             loop {
-                let input = term.read_char()?;
+                let input = term.read_key()?;
                 let value = match input {
-                    'y' | 'Y' => true,
-                    'n' | 'N' => false,
-                    '\n' | '\r' if self.default.is_some() => self.default.unwrap(),
+                    Key::Char('y') | Key::Char('Y') => true,
+                    Key::Char('n') | Key::Char('N') => false,
+                    Key::Enter if self.default.is_some() => self.default.unwrap(),
                     _ => {
                         continue;
                     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -40,12 +40,13 @@ pub trait Theme {
         &self,
         f: &mut dyn fmt::Write,
         prompt: &str,
-        selection: bool,
+        selection: Option<bool>,
     ) -> fmt::Result {
+        let selection = selection.map_or("n/a", |b| if b { "yes" } else { "no" });
         if prompt.is_empty() {
-            write!(f, "{}", if selection { "yes" } else { "no" })
+            write!(f, "{}", selection)
         } else {
-            write!(f, "{} {}", &prompt, if selection { "yes" } else { "no" })
+            write!(f, "{} {}", &prompt, selection)
         }
     }
 
@@ -366,7 +367,7 @@ impl Theme for ColorfulTheme {
         &self,
         f: &mut dyn fmt::Write,
         prompt: &str,
-        selection: bool,
+        selection: Option<bool>,
     ) -> fmt::Result {
         if !prompt.is_empty() {
             write!(
@@ -376,13 +377,13 @@ impl Theme for ColorfulTheme {
                 self.prompt_style.apply_to(prompt)
             )?;
         }
+        let selection = selection.map_or("n/a", |b| if b { "yes" } else { "no" });
 
         write!(
             f,
             "{} {}",
             &self.success_suffix,
-            self.values_style
-                .apply_to(if selection { "yes" } else { "no" })
+            self.values_style.apply_to(selection)
         )
     }
 
@@ -607,7 +608,7 @@ impl<'a> TermThemeRenderer<'a> {
         self.write_formatted_str(|this, buf| this.theme.format_confirm_prompt(buf, prompt, default))
     }
 
-    pub fn confirm_prompt_selection(&mut self, prompt: &str, sel: bool) -> io::Result<()> {
+    pub fn confirm_prompt_selection(&mut self, prompt: &str, sel: Option<bool>) -> io::Result<()> {
         self.write_formatted_prompt(|this, buf| {
             this.theme.format_confirm_prompt_selection(buf, prompt, sel)
         })

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -42,7 +42,7 @@ pub trait Theme {
         prompt: &str,
         selection: Option<bool>,
     ) -> fmt::Result {
-        let selection = selection.map_or("n/a", |b| if b { "yes" } else { "no" });
+        let selection = selection.map_or("cancel", |b| if b { "yes" } else { "no" });
         if prompt.is_empty() {
             write!(f, "{}", selection)
         } else {
@@ -377,7 +377,7 @@ impl Theme for ColorfulTheme {
                 self.prompt_style.apply_to(prompt)
             )?;
         }
-        let selection = selection.map_or("n/a", |b| if b { "yes" } else { "no" });
+        let selection = selection.map_or("cancel", |b| if b { "yes" } else { "no" });
 
         write!(
             f,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -42,11 +42,19 @@ pub trait Theme {
         prompt: &str,
         selection: Option<bool>,
     ) -> fmt::Result {
-        let selection = selection.map_or("cancel", |b| if b { "yes" } else { "no" });
-        if prompt.is_empty() {
-            write!(f, "{}", selection)
-        } else {
-            write!(f, "{} {}", &prompt, selection)
+        let selection = selection.map(|b| if b { "yes" } else { "no" });
+
+        match selection {
+            Some(selection) if prompt.is_empty() => {
+                write!(f, "{}", selection)
+            }
+            Some(selection) => {
+                write!(f, "{} {}", &prompt, selection)
+            }
+            None if prompt.is_empty() => Ok(()),
+            None => {
+                write!(f, "{}", &prompt)
+            }
         }
     }
 
@@ -377,14 +385,21 @@ impl Theme for ColorfulTheme {
                 self.prompt_style.apply_to(prompt)
             )?;
         }
-        let selection = selection.map_or("cancel", |b| if b { "yes" } else { "no" });
+        let selection = selection.map(|b| if b { "yes" } else { "no" });
 
-        write!(
-            f,
-            "{} {}",
-            &self.success_suffix,
-            self.values_style.apply_to(selection)
-        )
+        match selection {
+            Some(selection) => {
+                write!(
+                    f,
+                    "{} {}",
+                    &self.success_suffix,
+                    self.values_style.apply_to(selection)
+                )
+            }
+            None => {
+                write!(f, "{}", &self.success_suffix)
+            }
+        }
     }
 
     /// Formats an input prompt after selection.


### PR DESCRIPTION
Adds `Confirm::interact_opt` and `Confirm::interact_on_opt` to handle situations where the user
wishes to answer neither "yes" nor "no".

Resolves #100 

***

# Bug(s) to fix

- [x] When `default(true)`, `wait_for_newline(true)`, and `interact_opt` called on a `Confirm`, then `Esc` does not clear the final value -- `Esc` followed by `Enter` will return `Some(true)`, not `None`.