### PR TITLE
Use `console::measure_text_width` to generate size_vec in select

### DIFF
--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -159,8 +159,8 @@ impl<'a> MultiSelect<'a> {
             .flat_map(|i| i.split('\n'))
             .collect::<Vec<_>>()
         {
-            let size = &items.len();
-            size_vec.push(*size);
+            let size = console::measure_text_width(items);
+            size_vec.push(size);
         }
 
         let mut checked: Vec<bool> = self.defaults.clone();

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -276,8 +276,8 @@ impl<'a> Select<'a> {
             .flat_map(|i| i.split('\n'))
             .collect::<Vec<_>>()
         {
-            let size = &items.len();
-            size_vec.push(*size);
+            let size = console::measure_text_width(items);
+            size_vec.push(size);
         }
 
         loop {

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -126,8 +126,8 @@ impl<'a> Sort<'a> {
         let mut size_vec = Vec::new();
 
         for items in self.items.iter().as_slice() {
-            let size = &items.len();
-            size_vec.push(*size);
+            let size = console::measure_text_width(items);
+            size_vec.push(size);
         }
 
         let mut order: Vec<_> = (0..self.items.len()).collect();


### PR DESCRIPTION
This allows using ANSI escape codes in select items.

Previously line width are measured using `str::len`, which causes text with ANSI escape codes to be measured longer than they really are. Subsequently when clearing printed lines, additional lines can be cleared.