### PR TITLE
Make Editor and tempfile dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,12 @@ repository = "https://github.com/mitsuhiko/dialoguer"
 documentation = "https://docs.rs/dialoguer"
 readme = "README.md"
 
+[features]
+default = ["edit"]
+edit = ["tempfile"]
+
 [dependencies]
 console = "0.14.1"
 lazy_static = "1"
-tempfile = "3"
+tempfile = { version = "3", optional = true }
 zeroize = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/dialoguer"
 readme = "README.md"
 
 [features]
-default = ["edit"]
-edit = ["tempfile"]
+default = ["editor"]
+editor = ["tempfile"]
 
 [dependencies]
 console = "0.14.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //! * Editor launching
 
 pub use console;
+#[cfg(feature = "edit")]
 pub use edit::Editor;
 pub use prompts::{
     confirm::Confirm, input::Input, multi_select::MultiSelect, password::Password, select::Select,
@@ -25,6 +26,7 @@ pub use prompts::{
 };
 pub use validate::Validator;
 
+#[cfg(feature = "edit")]
 mod edit;
 mod prompts;
 pub mod theme;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! * Editor launching
 
 pub use console;
-#[cfg(feature = "edit")]
+#[cfg(feature = "editor")]
 pub use edit::Editor;
 pub use prompts::{
     confirm::Confirm, input::Input, multi_select::MultiSelect, password::Password, select::Select,
@@ -26,7 +26,7 @@ pub use prompts::{
 };
 pub use validate::Validator;
 
-#[cfg(feature = "edit")]
+#[cfg(feature = "editor")]
 mod edit;
 mod prompts;
 pub mod theme;


### PR DESCRIPTION
The `Editor` functionality currently depends on `tempfile` which is a pretty hefty dependency, so it would be nice if it were an optional feature since many uses of this library don't need the edit functionality.

With the current PR:

```bash
$ cargo tree --no-default-dependencies
dialoguer v0.8.0
├── console v0.14.1
│   ├── lazy_static v1.4.0
│   ├── libc v0.2.91
│   ├── regex v1.4.5
│   │   └── regex-syntax v0.6.23
│   ├── terminal_size v0.1.16
│   │   └── libc v0.2.91
│   └── unicode-width v0.1.8
├── lazy_static v1.4.0
└── zeroize v1.2.0
```

```bash
$ cargo tree # (with default features)
dialoguer v0.8.0
├── console v0.14.1
│   ├── lazy_static v1.4.0
│   ├── libc v0.2.91
│   ├── regex v1.4.5
│   │   └── regex-syntax v0.6.23
│   ├── terminal_size v0.1.16
│   │   └── libc v0.2.91
│   └── unicode-width v0.1.8
├── lazy_static v1.4.0
├── tempfile v3.2.0
│   ├── cfg-if v1.0.0
│   ├── libc v0.2.91
│   ├── rand v0.8.3
│   │   ├── libc v0.2.91
│   │   ├── rand_chacha v0.3.0
│   │   │   ├── ppv-lite86 v0.2.10
│   │   │   └── rand_core v0.6.2
│   │   │       └── getrandom v0.2.2
│   │   │           ├── cfg-if v1.0.0
│   │   │           └── libc v0.2.91
│   │   └── rand_core v0.6.2 (*)
│   └── remove_dir_all v0.5.3
└── zeroize v1.2.0
```
