### PR TITLE
Add must_use lint to interaction functions

### DIFF
--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -115,6 +115,7 @@ impl<'a> Confirm<'a> {
     /// Otherwise function discards input waiting for valid one.
     ///
     /// The dialog is rendered on stderr.
+    #[must_use = "Value must be used to have an effect"]
     pub fn interact(&self) -> io::Result<bool> {
         self.interact_on(&Term::stderr())
     }
@@ -124,6 +125,7 @@ impl<'a> Confirm<'a> {
     /// This method is similar to [interact_on_opt](#method.interact_on_opt) except for the fact that it does not allow selection of the terminal.
     /// The dialog is rendered on stderr.
     /// Result contains `Some(bool)` if user answered "yes" or "no" or `None` if user cancelled with 'Esc' or 'q'.
+    #[must_use = "Value must be used to have an effect"]
     pub fn interact_opt(&self) -> io::Result<Option<bool>> {
         self.interact_on_opt(&Term::stderr())
     }
@@ -143,6 +145,7 @@ impl<'a> Confirm<'a> {
     /// #   Ok(())
     /// # }
     /// ```
+    #[must_use = "Value must be used to have an effect"]
     pub fn interact_on(&self, term: &Term) -> io::Result<bool> {
         self._interact_on(term, false)?
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Quit not allowed in this case"))
@@ -167,6 +170,7 @@ impl<'a> Confirm<'a> {
     ///     Ok(())
     /// }
     /// ```
+    #[must_use = "Value must be used to have an effect"]
     pub fn interact_on_opt(&self, term: &Term) -> io::Result<Option<bool>> {
         self._interact_on(term, true)
     }


### PR DESCRIPTION
This is a draft because there's a problem with that patch:

* If one uses the `Result` part, the return value seems to be used and the compiler does not emit a warning for the unused `bool` value.

Maybe we can fix this somehow, I've [asked the community](https://users.rust-lang.org/t/must-use-lint-for-functions-returning-result/58746) how such a thing would be possible.