### PR TITLE
fix example build when editor feature isn't enabled

### DIFF
--- a/examples/editor.rs
+++ b/examples/editor.rs
@@ -1,10 +1,15 @@
-use dialoguer::Editor;
-
+#[cfg(feature = "editor")]
 fn main() {
+    use dialoguer::Editor;
     if let Some(rv) = Editor::new().edit("Enter a commit message").unwrap() {
         println!("Your message:");
         println!("{}", rv);
     } else {
         println!("Abort!");
     }
+}
+
+#[cfg(not(feature = "editor"))]
+fn main() {
+    println!("editor feature must be enabled.");
 }


### PR DESCRIPTION
I didn't realize it when I submitted the pull request, sorry.