### PR TITLE
make zeroize dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ documentation = "https://docs.rs/dialoguer"
 readme = "README.md"
 
 [features]
-default = ["editor"]
+default = ["editor", "zeroize-passwords"]
 editor = ["tempfile"]
+zeroize-passwords = ["zeroize"]
 
 [dependencies]
 console = "0.14.1"
-lazy_static = "1"
 tempfile = { version = "3", optional = true }
-zeroize = "1.1.1"
+zeroize = { version = "1.1.1", optional = true }


### PR DESCRIPTION
Similar to the `editor` feature change, making it simple for people to not have to bring in dependencies for features they don't use.