### PR TITLE
Add support for optional history processing to `Input`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ documentation = "https://docs.rs/dialoguer"
 readme = "README.md"
 
 [features]
-default = ["editor"]
+default = ["editor", "history"]
 editor = ["tempfile"]
 fuzzy-select = ["fuzzy-matcher"]
+history = []
 
 [dependencies]
 console = "0.14.1"

--- a/examples/history.rs
+++ b/examples/history.rs
@@ -1,0 +1,52 @@
+use dialoguer::{theme::ColorfulTheme, History, Input};
+use std::{collections::VecDeque, fmt::Display, process, str::FromStr};
+
+fn main() {
+    println!("Use 'exit' to quit the prompt");
+    println!("In this example, history is limited to 4 entries");
+    println!("Use the Up/Down arrows to scroll through history");
+    println!();
+    let mut history = MyHistory::default();
+    loop {
+        if let Ok(cmd) = Input::<String>::with_theme(&ColorfulTheme::default())
+            .with_prompt("dialoguer")
+            .history_with(&mut history)
+            .interact_text()
+        {
+            if cmd == "exit" {
+                process::exit(0);
+            }
+            println!("Entered {}", cmd);
+        }
+    }
+}
+
+struct MyHistory {
+    max: usize,
+    history: VecDeque<String>,
+}
+
+impl Default for MyHistory {
+    fn default() -> Self {
+        MyHistory {
+            max: 4,
+            history: VecDeque::new(),
+        }
+    }
+}
+
+impl<T> History<T> for MyHistory {
+    fn read(&self, pos: usize) -> Option<String> {
+        self.history.get(pos).cloned()
+    }
+
+    fn write(&mut self, val: &T)
+    where
+        T: Clone + FromStr + Display,
+    {
+        if self.history.len() == self.max {
+            self.history.pop_back();
+        }
+        self.history.push_front(val.to_string());
+    }
+}

--- a/examples/history.rs
+++ b/examples/history.rs
@@ -1,5 +1,5 @@
 use dialoguer::{theme::ColorfulTheme, History, Input};
-use std::{collections::VecDeque, fmt::Display, process, str::FromStr};
+use std::{collections::VecDeque, fmt::Display, process};
 
 fn main() {
     println!("Use 'exit' to quit the prompt");
@@ -42,7 +42,7 @@ impl<T> History<T> for MyHistory {
 
     fn write(&mut self, val: &T)
     where
-        T: Clone + FromStr + Display,
+        T: Clone + Display,
     {
         if self.history.len() == self.max {
             self.history.pop_back();

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,18 @@
+use std::{fmt::Display, str::FromStr};
+
+/// Trait for history handling
+pub trait History<T> {
+    /// This is called with the current position that should
+    /// be read from history.  The `pos` represents the number
+    /// of times the `Up`/`Down` arrow key has been pressed.
+    /// This would normally be used as an index to some sort
+    /// of vector.  If the `pos` does not have an entry, [`None`](Option::None)
+    /// should be returned.
+    fn read(&self, pos: usize) -> Option<String>;
+    /// This is called with the next value you should store
+    /// in history at the first location.  Normally history
+    /// is implemented as a FIFO queue.
+    fn write(&mut self, val: &T)
+    where
+        T: Clone + FromStr + Display;
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, str::FromStr};
+use std::fmt::Display;
 
 /// Trait for history handling
 pub trait History<T> {
@@ -14,5 +14,5 @@ pub trait History<T> {
     /// is implemented as a FIFO queue.
     fn write(&mut self, val: &T)
     where
-        T: Clone + FromStr + Display;
+        T: Clone + Display;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@
 pub use console;
 #[cfg(feature = "editor")]
 pub use edit::Editor;
+#[cfg(feature = "history")]
+pub use history::History;
 pub use prompts::{
     confirm::Confirm, input::Input, multi_select::MultiSelect, password::Password, select::Select,
     sort::Sort,
@@ -31,6 +33,8 @@ pub use prompts::fuzzy_select::FuzzySelect;
 
 #[cfg(feature = "editor")]
 mod edit;
+#[cfg(feature = "history")]
+mod history;
 mod prompts;
 pub mod theme;
 mod validate;

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -164,7 +164,37 @@ where
         self
     }
 
-    /// Enable history
+    /// Enable history processing
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use dialoguer::Input;
+    /// # use std::collections::VecDeque;
+    /// let mut history = VecDeque::<String>::new();
+    /// loop {
+    ///     if let Ok(input) = Input::<String>::new()
+    ///         .with_prompt("hist")
+    ///         .history_with(|pos: usize, val_opt: Option<&String>| {
+    ///             // If the option has a value it should be stored in
+    ///             // history.  Otherwise, the pos argument can be used
+    ///             // to lookup a value from your history.  This value
+    ///             // represents how many times the up/down arrow has been
+    ///             // pressed and would normally be an index into a
+    ///             // vector.
+    ///             if let Some(val) = val_opt {
+    ///                 history.push_front(val.clone());
+    ///                 None
+    ///             } else {
+    ///                 history.get(pos).cloned()
+    ///             }
+    ///         })
+    ///         .interact_text()
+    ///     {
+    ///         // Do something with the input
+    ///     }
+    /// }
+    /// ```
     pub fn history_with<R>(&mut self, history: R) -> &mut Input<'a, T>
     where
         R: FnMut(usize, Option<&T>) -> Option<String> + 'a,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -211,36 +211,20 @@ pub trait Theme {
         f: &mut dyn fmt::Write,
         prompt: &str,
         search_term: &str,
-        cursor_pos: usize
+        cursor_pos: usize,
     ) -> fmt::Result {
-
         if !prompt.is_empty() {
-            write!(
-                f,
-                "{} ",
-                prompt,
-            )?;
+            write!(f, "{} ", prompt,)?;
         }
 
         if cursor_pos < search_term.len() {
             let st_head = search_term[0..cursor_pos].to_string();
             let st_tail = search_term[cursor_pos..search_term.len()].to_string();
-            let st_cursor = "|".to_string();  
-            write!(
-                f,
-                "{}{}{}",
-                st_head,
-                st_cursor,
-                st_tail
-            )
+            let st_cursor = "|".to_string();
+            write!(f, "{}{}{}", st_head, st_cursor, st_tail)
         } else {
-            let cursor = "|".to_string();  
-            write!(
-                f,
-                "{}{}",
-                search_term.to_string(),
-                cursor
-            )
+            let cursor = "|".to_string();
+            write!(f, "{}{}", search_term.to_string(), cursor)
         }
     }
 }
@@ -596,9 +580,8 @@ impl Theme for ColorfulTheme {
         f: &mut dyn fmt::Write,
         prompt: &str,
         search_term: &str,
-        cursor_pos: usize
+        cursor_pos: usize,
     ) -> fmt::Result {
-
         if !prompt.is_empty() {
             write!(
                 f,
@@ -610,16 +593,15 @@ impl Theme for ColorfulTheme {
 
         if cursor_pos < search_term.len() {
             let st_head = search_term[0..cursor_pos].to_string();
-            let st_tail = search_term[cursor_pos+1..search_term.len()].to_string();
-            let st_cursor = self.fuzzy_cursor_style.apply_to(search_term.to_string().chars().nth(cursor_pos).unwrap());
+            let st_tail = search_term[cursor_pos + 1..search_term.len()].to_string();
+            let st_cursor = self
+                .fuzzy_cursor_style
+                .apply_to(search_term.to_string().chars().nth(cursor_pos).unwrap());
             write!(
                 f,
                 "{} {}{}{}",
-                &self.prompt_suffix,
-                st_head,
-                st_cursor,
-                st_tail
-            )  
+                &self.prompt_suffix, st_head, st_cursor, st_tail
+            )
         } else {
             let cursor = self.fuzzy_cursor_style.apply_to(" ");
             write!(
@@ -718,9 +700,15 @@ impl<'a> TermThemeRenderer<'a> {
     }
 
     #[cfg(feature = "fuzzy-select")]
-    pub fn fuzzy_select_prompt(&mut self, prompt: &str, search_term: &str, cursor_pos: usize) -> io::Result<()> {
+    pub fn fuzzy_select_prompt(
+        &mut self,
+        prompt: &str,
+        search_term: &str,
+        cursor_pos: usize,
+    ) -> io::Result<()> {
         self.write_formatted_prompt(|this, buf| {
-            this.theme.format_fuzzy_select_prompt(buf, prompt, search_term, cursor_pos)
+            this.theme
+                .format_fuzzy_select_prompt(buf, prompt, search_term, cursor_pos)
         })
     }
 


### PR DESCRIPTION
* Added support for optional history processing to `Input`.  

Up/Down arrow keys are read in `interact_text_on` and allow for history to be read via a user supplied function.
History is written after successful input validation via the same user supplied function.