### PR TITLE
Fix paging

### DIFF
--- a/examples/paging.rs
+++ b/examples/paging.rs
@@ -6,9 +6,9 @@ fn main() {
         "Vanilla Cupcake",
         "Chocolate Muffin",
         "A Pile of sweet, sweet mustard",
-        "Foo",
-        "Bar",
-        "Baz",
+        "Carrots",
+        "Peas",
+        "Pistacio",
         "Mustard",
         "Cream",
         "Banana",
@@ -17,7 +17,7 @@ fn main() {
         "Corn",
         "Cake",
         "Tarte",
-        "Clear glaze",
+        "Cheddar",
         "Vanilla",
         "Hazelnut",
         "Flour",
@@ -29,7 +29,7 @@ fn main() {
         "Mousse au chocolat",
         "Brown sugar",
         "Blueberry",
-        "Blanc",
+        "Burger",
     ];
 
     let selection = Select::with_theme(&ColorfulTheme::default())
@@ -40,5 +40,4 @@ fn main() {
         .unwrap();
 
     println!("Enjoy your {}!", selections[selection]);
-
 }

--- a/examples/paging.rs
+++ b/examples/paging.rs
@@ -1,0 +1,44 @@
+use dialoguer::{theme::ColorfulTheme, Select};
+
+fn main() {
+    let selections = &[
+        "Ice Cream",
+        "Vanilla Cupcake",
+        "Chocolate Muffin",
+        "A Pile of sweet, sweet mustard",
+        "Foo",
+        "Bar",
+        "Baz",
+        "Mustard",
+        "Cream",
+        "Banana",
+        "Chocolate",
+        "Flakes",
+        "Corn",
+        "Cake",
+        "Tarte",
+        "Clear glaze",
+        "Vanilla",
+        "Hazelnut",
+        "Flour",
+        "Sugar",
+        "Salt",
+        "Potato",
+        "French Fries",
+        "Pizza",
+        "Mousse au chocolat",
+        "Brown sugar",
+        "Blueberry",
+        "Blanc",
+    ];
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Pick your flavor")
+        .default(0)
+        .items(&selections[..])
+        .interact()
+        .unwrap();
+
+    println!("Enjoy your {}!", selections[selection]);
+
+}

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -6,27 +6,52 @@ fn main() {
         "Vanilla Cupcake",
         "Chocolate Muffin",
         "A Pile of sweet, sweet mustard",
+        "Foo",
+        "Bar",
+        "Baz",
+        "Mustard",
+        "Cream",
+        "Banana",
+        "Chocolate",
+        "Flakes",
+        "Corn",
+        "Cake",
+        "Tarte",
+        "Clear glaze",
+        "Vanilla",
+        "Hazelnut",
+        "Flour",
+        "Sugar",
+        "Salt",
+        "Potato",
+        "French Fries",
+        "Pizza",
+        "Mousse au chocolat",
+        "Brown sugar",
+        "Blueberry",
+        "Blanc",
     ];
 
     let selection = Select::with_theme(&ColorfulTheme::default())
         .with_prompt("Pick your flavor")
         .default(0)
+        .paged(true)
         .items(&selections[..])
         .interact()
         .unwrap();
 
     println!("Enjoy your {}!", selections[selection]);
 
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Optionally pick your flavor")
-        .default(0)
-        .items(&selections[..])
-        .interact_opt()
-        .unwrap();
+    // let selection = Select::with_theme(&ColorfulTheme::default())
+    //     .with_prompt("Optionally pick your flavor")
+    //     .default(0)
+    //     .items(&selections[..])
+    //     .interact_opt()
+    //     .unwrap();
 
-    if let Some(selection) = selection {
-        println!("Enjoy your {}!", selections[selection]);
-    } else {
-        println!("You didn't select anything!");
-    }
+    // if let Some(selection) = selection {
+    //     println!("Enjoy your {}!", selections[selection]);
+    // } else {
+    //     println!("You didn't select anything!");
+    // }
 }

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -6,52 +6,27 @@ fn main() {
         "Vanilla Cupcake",
         "Chocolate Muffin",
         "A Pile of sweet, sweet mustard",
-        "Foo",
-        "Bar",
-        "Baz",
-        "Mustard",
-        "Cream",
-        "Banana",
-        "Chocolate",
-        "Flakes",
-        "Corn",
-        "Cake",
-        "Tarte",
-        "Clear glaze",
-        "Vanilla",
-        "Hazelnut",
-        "Flour",
-        "Sugar",
-        "Salt",
-        "Potato",
-        "French Fries",
-        "Pizza",
-        "Mousse au chocolat",
-        "Brown sugar",
-        "Blueberry",
-        "Blanc",
     ];
 
     let selection = Select::with_theme(&ColorfulTheme::default())
         .with_prompt("Pick your flavor")
         .default(0)
-        .paged(true)
         .items(&selections[..])
         .interact()
         .unwrap();
 
     println!("Enjoy your {}!", selections[selection]);
 
-    // let selection = Select::with_theme(&ColorfulTheme::default())
-    //     .with_prompt("Optionally pick your flavor")
-    //     .default(0)
-    //     .items(&selections[..])
-    //     .interact_opt()
-    //     .unwrap();
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Optionally pick your flavor")
+        .default(0)
+        .items(&selections[..])
+        .interact_opt()
+        .unwrap();
 
-    // if let Some(selection) = selection {
-    //     println!("Enjoy your {}!", selections[selection]);
-    // } else {
-    //     println!("You didn't select anything!");
-    // }
+    if let Some(selection) = selection {
+        println!("Enjoy your {}!", selections[selection]);
+    } else {
+        println!("You didn't select anything!");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use prompts::{
     sort::Sort,
 };
 pub use validate::Validator;
+pub use paging::Paging;
 
 #[cfg(feature = "fuzzy-select")]
 pub use prompts::fuzzy_select::FuzzySelect;
@@ -38,3 +39,4 @@ mod history;
 mod prompts;
 pub mod theme;
 mod validate;
+mod paging;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use prompts::{
     confirm::Confirm, input::Input, multi_select::MultiSelect, select::Select, sort::Sort,
 };
 pub use validate::Validator;
-pub use paging::Paging;
+use paging::Paging;
 
 #[cfg(feature = "fuzzy-select")]
 pub use prompts::fuzzy_select::FuzzySelect;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,11 @@ pub use console;
 pub use edit::Editor;
 #[cfg(feature = "history")]
 pub use history::History;
+use paging::Paging;
 pub use prompts::{
     confirm::Confirm, input::Input, multi_select::MultiSelect, select::Select, sort::Sort,
 };
 pub use validate::Validator;
-use paging::Paging;
 
 #[cfg(feature = "fuzzy-select")]
 pub use prompts::fuzzy_select::FuzzySelect;
@@ -38,7 +38,7 @@ pub use prompts::password::Password;
 mod edit;
 #[cfg(feature = "history")]
 mod history;
+mod paging;
 mod prompts;
 pub mod theme;
 mod validate;
-mod paging;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -89,25 +89,6 @@ impl<'a> Paging<'a> {
         Ok(())
     }
 
-    pub fn render_items<F: FnMut(usize, &String) -> io::Result<()>>(
-        &mut self,
-        mut render_item: F,
-    ) -> io::Result<()> {
-        for (idx, item) in self
-            .items
-            .iter()
-            .enumerate()
-            .skip(self.current_page * self.capacity)
-            .take(self.capacity)
-        {
-            render_item(idx, item).map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-        }
-
-        self.term.flush()?;
-
-        Ok(())
-    }
-
     pub fn next_page(&mut self) -> usize {
         if self.current_page == self.pages - 1 {
             self.current_page = 0;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -26,7 +26,7 @@ impl<'a> Paging<'a> {
             capacity,
             items,
             active: pages > 1,
-            activity_transition: true
+            activity_transition: true,
         }
     }
 
@@ -75,7 +75,6 @@ impl<'a> Paging<'a> {
         &mut self,
         mut render_prompt: F,
     ) -> io::Result<()> {
-        
         let mut paging_info = None;
 
         if self.active {

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1,4 +1,4 @@
-use std::{fmt, io};
+use std::io;
 
 use console::Term;
 

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -19,6 +19,7 @@ pub struct Paging<'a> {
 
 impl<'a> Paging<'a> {
     pub fn new(term: &'a Term, items_len: usize) -> Paging<'a> {
+        // Subtract -2 because we need space to render the prompt, if paging is active
         let capacity = term.size().0 as usize - 2;
         let pages = (items_len as f64 / capacity as f64).ceil() as usize;
 
@@ -30,6 +31,7 @@ impl<'a> Paging<'a> {
             capacity,
             items_len,
             active: pages > 1,
+            // Set transition initially to true to trigger prompt rendering for inactive paging on start
             activity_transition: true,
         }
     }
@@ -45,6 +47,7 @@ impl<'a> Paging<'a> {
         if self.active != (self.pages > 1) {
             self.active = self.pages > 1;
             self.activity_transition = true;
+            // Clear everything to prevent "ghost" lines in terminal when a resize happened
             self.term.clear_last_lines(self.capacity)?;
         } else {
             self.activity_transition = false;
@@ -80,7 +83,7 @@ impl<'a> Paging<'a> {
         self.current_page
     }
 
-    /// Renders a prompt for paging when the following conditions are met:
+    /// Renders a prompt when the following conditions are met:
     /// * Paging is active
     /// * Transition of the paging activity happened (active -> inactive / inactive -> active)
     pub fn render_prompt<F: FnMut(Option<(usize, usize)>) -> io::Result<()>>(

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -2,21 +2,25 @@ use std::io;
 
 use console::Term;
 
+/// Creates a paging module
+///
+/// The paging module serves as tracking structure to allow paged views
+/// and automatically (de-)activates paging depending on the current terminal size.
 pub struct Paging<'a> {
     term: &'a Term,
     current_term_size: (u16, u16),
     pages: usize,
     current_page: usize,
     capacity: usize,
-    items: &'a Vec<String>,
+    items_len: usize,
     active: bool,
     activity_transition: bool,
 }
 
 impl<'a> Paging<'a> {
-    pub fn new(term: &'a Term, items: &'a Vec<String>) -> Paging<'a> {
+    pub fn new(term: &'a Term, items_len: usize) -> Paging<'a> {
         let capacity = term.size().0 as usize - 2;
-        let pages = (items.len() as f64 / capacity as f64).ceil() as usize;
+        let pages = (items_len as f64 / capacity as f64).ceil() as usize;
 
         Paging {
             term,
@@ -24,7 +28,7 @@ impl<'a> Paging<'a> {
             pages,
             current_page: 0,
             capacity,
-            items,
+            items_len,
             active: pages > 1,
             activity_transition: true,
         }
@@ -34,7 +38,7 @@ impl<'a> Paging<'a> {
         if self.current_term_size != self.term.size() {
             self.current_term_size = self.term.size();
             self.capacity = self.current_term_size.0 as usize - 2;
-            self.pages = (self.items.len() as f64 / self.capacity as f64).ceil() as usize;
+            self.pages = (self.items_len as f64 / self.capacity as f64).ceil() as usize;
         }
 
         if self.active != (self.pages > 1) {

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -35,7 +35,6 @@ impl<'a> Paging<'a> {
             self.capacity = self.current_term_size.0 as usize - 2;
             self.pages = (self.items.len() as f64 / self.capacity as f64).ceil() as usize;
             self.active = self.pages > 1;
-            self.term.clear_last_lines(self.capacity)?;
         }
 
         if sel != !0

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -63,8 +63,26 @@ impl<'a> Paging<'a> {
         self.current_page
     }
 
-    pub fn render_page_items<F: FnMut(usize, &String) -> io::Result<()>>(
-        &self,
+    pub fn render_prompt<F: FnMut(Option<(usize, usize)>) -> io::Result<()>>(
+        &mut self,
+        mut render_prompt: F,
+    ) -> io::Result<()> {
+        
+        let mut paging_info = None;
+
+        if self.active {
+            paging_info = Some((self.current_page + 1, self.pages));
+        }
+
+        render_prompt(paging_info)?;
+
+        self.term.flush()?;
+
+        Ok(())
+    }
+
+    pub fn render_items<F: FnMut(usize, &String) -> io::Result<()>>(
+        &mut self,
         mut render_item: F,
     ) -> io::Result<()> {
         for (idx, item) in self

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -9,7 +9,7 @@ pub struct Paging<'a> {
     current_page: usize,
     capacity: usize,
     items: &'a Vec<String>,
-    enabled: bool,
+    active: bool,
 }
 
 impl<'a> Paging<'a> {
@@ -25,7 +25,7 @@ impl<'a> Paging<'a> {
             current_page: 0,
             capacity,
             items,
-            enabled: pages > 1,
+            active: pages > 1,
         }
     }
 
@@ -34,7 +34,7 @@ impl<'a> Paging<'a> {
             self.current_term_size = self.term.size();
             self.capacity = self.current_term_size.0 as usize - 2;
             self.pages = (self.items.len() as f64 / self.capacity as f64).ceil() as usize;
-            self.enabled = self.pages > 1;
+            self.active = self.pages > 1;
             self.term.clear_last_lines(self.capacity)?;
         }
 
@@ -48,8 +48,8 @@ impl<'a> Paging<'a> {
         Ok(())
     }
 
-    pub fn enabled(&self) -> bool {
-        self.enabled
+    pub fn active(&self) -> bool {
+        self.active
     }
 
     pub fn capacity(&self) -> usize {

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -34,7 +34,8 @@ impl<'a> Paging<'a> {
         }
     }
 
-    pub fn update(&mut self, sel: usize) -> io::Result<()> {
+    /// Updates all internal based on the current terminal size and cursor position
+    pub fn update(&mut self, cursor_pos: usize) -> io::Result<()> {
         if self.current_term_size != self.term.size() {
             self.current_term_size = self.term.size();
             self.capacity = self.current_term_size.0 as usize - 2;
@@ -49,32 +50,39 @@ impl<'a> Paging<'a> {
             self.activity_transition = false;
         }
 
-        if sel != !0
-            && (sel < self.current_page * self.capacity
-                || sel >= (self.current_page + 1) * self.capacity)
+        if cursor_pos != !0
+            && (cursor_pos < self.current_page * self.capacity
+                || cursor_pos >= (self.current_page + 1) * self.capacity)
         {
-            self.current_page = sel / self.capacity;
+            self.current_page = cursor_pos / self.capacity;
         }
 
         Ok(())
     }
 
+    /// Returns current acivity state
     pub fn active(&self) -> bool {
         self.active
     }
 
+    /// Returns capacity
     pub fn capacity(&self) -> usize {
         self.capacity
     }
 
+    /// Returns number of pages
     pub fn pages(&self) -> usize {
         self.pages
     }
 
+    /// Returns current page
     pub fn current_page(&self) -> usize {
         self.current_page
     }
 
+    /// Renders a prompt for paging when the following conditions are met:
+    /// * Paging is active
+    /// * Transition of the paging activity happened (active -> inactive / inactive -> active)
     pub fn render_prompt<F: FnMut(Option<(usize, usize)>) -> io::Result<()>>(
         &mut self,
         mut render_prompt: F,
@@ -93,6 +101,7 @@ impl<'a> Paging<'a> {
         Ok(())
     }
 
+    /// Navigates to the next page
     pub fn next_page(&mut self) -> usize {
         if self.current_page == self.pages - 1 {
             self.current_page = 0;
@@ -103,6 +112,7 @@ impl<'a> Paging<'a> {
         self.current_page * self.capacity
     }
 
+    /// Navigates to the previous page
     pub fn previous_page(&mut self) -> usize {
         if self.current_page == 0 {
             self.current_page = self.pages - 1;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1,0 +1,105 @@
+use std::{fmt, io};
+
+use console::Term;
+
+pub struct Paging<'a> {
+    term: &'a Term,
+    current_term_size: (u16, u16),
+    pages: usize,
+    current_page: usize,
+    capacity: usize,
+    items: &'a Vec<String>,
+    enabled: bool,
+}
+
+impl<'a> Paging<'a> {
+    pub fn new(term: &'a Term, items: &'a Vec<String>) -> Paging<'a> {
+        // Substract 2, because we show the prompt and/or page info on every page
+        let capacity = term.size().0 as usize - 2;
+        let pages = (items.len() as f64 / capacity as f64).ceil() as usize;
+
+        Paging {
+            term,
+            current_term_size: term.size(),
+            pages,
+            current_page: 0,
+            capacity,
+            items,
+            enabled: pages > 1,
+        }
+    }
+
+    pub fn update(&mut self, sel: usize) -> io::Result<()> {
+        if self.current_term_size != self.term.size() {
+            self.current_term_size = self.term.size();
+            self.capacity = self.current_term_size.0 as usize - 2;
+            self.pages = (self.items.len() as f64 / self.capacity as f64).ceil() as usize;
+            self.enabled = self.pages > 1;
+            self.term.clear_last_lines(self.capacity)?;
+        }
+
+        if sel != !0
+            && (sel < self.current_page * self.capacity
+                || sel >= (self.current_page + 1) * self.capacity)
+        {
+            self.current_page = sel / self.capacity;
+        }
+
+        Ok(())
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn pages(&self) -> usize {
+        self.pages
+    }
+
+    pub fn current_page(&self) -> usize {
+        self.current_page
+    }
+
+    pub fn render_page_items<F: FnMut(usize, &String) -> io::Result<()>>(
+        &self,
+        mut render_item: F,
+    ) -> io::Result<()> {
+        for (idx, item) in self
+            .items
+            .iter()
+            .enumerate()
+            .skip(self.current_page * self.capacity)
+            .take(self.capacity)
+        {
+            render_item(idx, item).map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        }
+
+        self.term.flush()?;
+
+        Ok(())
+    }
+
+    pub fn next_page(&mut self) -> usize {
+        if self.current_page == self.pages - 1 {
+            self.current_page = 0;
+        } else {
+            self.current_page += 1;
+        }
+
+        self.current_page * self.capacity
+    }
+
+    pub fn previous_page(&mut self) -> usize {
+        if self.current_page == 0 {
+            self.current_page = self.pages - 1;
+        } else {
+            self.current_page -= 1;
+        }
+
+        self.current_page * self.capacity
+    }
+}

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -52,15 +52,6 @@ impl<'a> MultiSelect<'a> {
         }
     }
 
-    /// Enables or disables paging
-    #[deprecated(
-        since = "0.9.0",
-        note = "Activating paging has no effect anymore. Paging will be activated automatically if needed."
-    )]
-    pub fn paged(&mut self, _val: bool) -> &mut MultiSelect<'a> {
-        self
-    }
-
     /// Sets the clear behavior of the menu.
     ///
     /// The default is to clear the menu.

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -159,8 +159,8 @@ impl<'a> MultiSelect<'a> {
                 .items
                 .iter()
                 .enumerate()
-                .skip(paging.current_page() * paging.capacity())
-                .take(paging.capacity())
+                .skip(paging.current_page * paging.capacity)
+                .take(paging.capacity)
             {
                 render.multi_select_prompt_item(item, checked[idx], sel == idx)?;
             }
@@ -184,12 +184,12 @@ impl<'a> MultiSelect<'a> {
                     }
                 }
                 Key::ArrowLeft | Key::Char('h') => {
-                    if paging.active() {
+                    if paging.active {
                         sel = paging.previous_page();
                     }
                 }
                 Key::ArrowRight | Key::Char('l') => {
-                    if paging.active() {
+                    if paging.active {
                         sel = paging.next_page();
                     }
                 }
@@ -251,7 +251,7 @@ impl<'a> MultiSelect<'a> {
 
             paging.update(sel)?;
 
-            if paging.active() {
+            if paging.active {
                 render.clear()?;
             } else {
                 render.clear_preserve_prompt(&size_vec)?;

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -55,6 +55,10 @@ impl<'a> MultiSelect<'a> {
     }
 
     /// Enables or disables paging
+    #[deprecated(
+        since = "0.9.0",
+        note = "Activating paging has no effect anymore. Paging will be activated automatically if needed."
+    )]
     pub fn paged(&mut self, val: bool) -> &mut MultiSelect<'a> {
         self.paged = val;
         self

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -1,6 +1,9 @@
 use std::{io, iter::repeat, ops::Rem};
 
-use crate::{Paging, theme::{SimpleTheme, TermThemeRenderer, Theme}};
+use crate::{
+    theme::{SimpleTheme, TermThemeRenderer, Theme},
+    Paging,
+};
 
 use console::{Key, Term};
 
@@ -155,12 +158,22 @@ impl<'a> MultiSelect<'a> {
         term.hide_cursor()?;
 
         loop {
-
             if let Some(ref prompt) = self.prompt {
-                paging.render_prompt(| paging_info | render.multi_select_prompt(prompt, paging_info))?;
+                paging
+                    .render_prompt(|paging_info| render.multi_select_prompt(prompt, paging_info))?;
             }
 
-            paging.render_items(|idx, item| render.multi_select_prompt_item(item, checked[idx], sel == idx))?;
+            for (idx, item) in self
+                .items
+                .iter()
+                .enumerate()
+                .skip(paging.current_page() * paging.capacity())
+                .take(paging.capacity())
+            {
+                render.multi_select_prompt_item(item, checked[idx], sel == idx)?;
+            }
+
+            term.flush()?;
 
             match term.read_key()? {
                 Key::ArrowDown | Key::Char('j') => {

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -27,7 +27,6 @@ pub struct MultiSelect<'a> {
     prompt: Option<String>,
     clear: bool,
     theme: &'a dyn Theme,
-    paged: bool,
 }
 
 impl<'a> Default for MultiSelect<'a> {
@@ -50,7 +49,6 @@ impl<'a> MultiSelect<'a> {
             clear: true,
             prompt: None,
             theme,
-            paged: false,
         }
     }
 
@@ -59,8 +57,7 @@ impl<'a> MultiSelect<'a> {
         since = "0.9.0",
         note = "Activating paging has no effect anymore. Paging will be activated automatically if needed."
     )]
-    pub fn paged(&mut self, val: bool) -> &mut MultiSelect<'a> {
-        self.paged = val;
+    pub fn paged(&mut self, _val: bool) -> &mut MultiSelect<'a> {
         self
     }
 

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -138,7 +138,7 @@ impl<'a> MultiSelect<'a> {
             ));
         }
 
-        let mut paging = Paging::new(term, &self.items);
+        let mut paging = Paging::new(term, self.items.len());
         let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = 0;
 

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -335,7 +335,12 @@ impl<'a> Select<'a> {
             }
 
             paging.update(sel)?;
-            render.clear_preserve_prompt(&size_vec)?;
+
+            if paging.active() {
+                render.clear()?;
+            } else {
+                render.clear_preserve_prompt(&size_vec)?;
+            }
         }
     }
 }

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -40,7 +40,6 @@ pub struct Select<'a> {
     prompt: Option<String>,
     clear: bool,
     theme: &'a dyn Theme,
-    paged: bool,
 }
 
 impl<'a> Default for Select<'a> {
@@ -80,7 +79,6 @@ impl<'a> Select<'a> {
             prompt: None,
             clear: true,
             theme,
-            paged: false,
         }
     }
 
@@ -91,8 +89,7 @@ impl<'a> Select<'a> {
         since = "0.9.0",
         note = "Activating paging has no effect anymore. Paging will be activated automatically if needed."
     )]
-    pub fn paged(&mut self, val: bool) -> &mut Select<'a> {
-        self.paged = val;
+    pub fn paged(&mut self, _val: bool) -> &mut Select<'a> {
         self
     }
 

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -87,6 +87,7 @@ impl<'a> Select<'a> {
     /// Enables or disables paging
     ///
     /// Paging is disabled by default
+    #[deprecated(since="0.9.0", note="Activating paging has no effect anymore. Paging will be activated automatically if needed.")]
     pub fn paged(&mut self, val: bool) -> &mut Select<'a> {
         self.paged = val;
         self
@@ -278,6 +279,11 @@ impl<'a> Select<'a> {
         loop {
             paging.update(sel)?;
 
+            // This should go somewhere else
+            // We also need to handle the following case:
+            // Paging was active, terminal is resized to a size where paging is disabled
+            // -> (Unpaged) Prompt must be written at the top of the screen
+
             if paging.enabled() {
                 // This may be redundant to last statement in loop
                 // But is needed to prevent the prompt to be written multiple times
@@ -318,12 +324,12 @@ impl<'a> Select<'a> {
                     }
                 }
                 Key::ArrowLeft | Key::Char('h') => {
-                    if self.paged {
+                    if paging.enabled() {
                         sel = paging.previous_page();
                     }
                 }
                 Key::ArrowRight | Key::Char('l') => {
-                    if self.paged {
+                    if paging.enabled() {
                         sel = paging.next_page();
                     }
                 }

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -269,8 +269,8 @@ impl<'a> Select<'a> {
                 .items
                 .iter()
                 .enumerate()
-                .skip(paging.current_page() * paging.capacity())
-                .take(paging.capacity())
+                .skip(paging.current_page * paging.capacity)
+                .take(paging.capacity)
             {
                 render.select_prompt_item(item, sel == idx)?;
             }
@@ -305,12 +305,12 @@ impl<'a> Select<'a> {
                     }
                 }
                 Key::ArrowLeft | Key::Char('h') => {
-                    if paging.active() {
+                    if paging.active {
                         sel = paging.previous_page();
                     }
                 }
                 Key::ArrowRight | Key::Char('l') => {
-                    if paging.active() {
+                    if paging.active {
                         sel = paging.next_page();
                     }
                 }
@@ -334,7 +334,7 @@ impl<'a> Select<'a> {
 
             paging.update(sel)?;
 
-            if paging.active() {
+            if paging.active {
                 render.clear()?;
             } else {
                 render.clear_preserve_prompt(&size_vec)?;

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -242,8 +242,8 @@ impl<'a> Select<'a> {
             ));
         }
 
-        let mut render = TermThemeRenderer::new(term, self.theme);
         let mut paging = Paging::new(term, self.items.len());
+        let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = self.default;
 
         let mut size_vec = Vec::new();

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -254,7 +254,7 @@ impl<'a> Select<'a> {
         }
 
         let mut render = TermThemeRenderer::new(term, self.theme);
-        let mut paging = Paging::new(term, &self.items);
+        let mut paging = Paging::new(term, self.items.len());
         let mut sel = self.default;
 
         let mut size_vec = Vec::new();

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -82,17 +82,6 @@ impl<'a> Select<'a> {
         }
     }
 
-    /// Enables or disables paging
-    ///
-    /// Paging is disabled by default
-    #[deprecated(
-        since = "0.9.0",
-        note = "Activating paging has no effect anymore. Paging will be activated automatically if needed."
-    )]
-    pub fn paged(&mut self, _val: bool) -> &mut Select<'a> {
-        self
-    }
-
     /// Indicates whether select menu should be erased from the screen after interaction.
     ///
     /// The default is to clear the menu.

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -1,7 +1,7 @@
 use std::{io, ops::Rem};
 
-use crate::theme::{SimpleTheme, TermThemeRenderer, Theme};
 use crate::paging::Paging;
+use crate::theme::{SimpleTheme, TermThemeRenderer, Theme};
 
 use console::{Key, Term};
 
@@ -87,7 +87,10 @@ impl<'a> Select<'a> {
     /// Enables or disables paging
     ///
     /// Paging is disabled by default
-    #[deprecated(since="0.9.0", note="Activating paging has no effect anymore. Paging will be activated automatically if needed.")]
+    #[deprecated(
+        since = "0.9.0",
+        note = "Activating paging has no effect anymore. Paging will be activated automatically if needed."
+    )]
     pub fn paged(&mut self, val: bool) -> &mut Select<'a> {
         self.paged = val;
         self
@@ -246,7 +249,6 @@ impl<'a> Select<'a> {
 
     /// Like `interact` but allows a specific terminal to be set.
     fn _interact_on(&self, term: &Term, allow_quit: bool) -> io::Result<Option<usize>> {
-
         if self.items.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -277,7 +279,17 @@ impl<'a> Select<'a> {
                 paging.render_prompt(|paging_info| render.select_prompt(prompt, paging_info))?;
             }
 
-            paging.render_items(|idx, item| render.select_prompt_item(item, sel == idx))?;
+            for (idx, item) in self
+                .items
+                .iter()
+                .enumerate()
+                .skip(paging.current_page() * paging.capacity())
+                .take(paging.capacity())
+            {
+                render.select_prompt_item(item, sel == idx)?;
+            }
+
+            term.flush()?;
 
             match term.read_key()? {
                 Key::ArrowDown | Key::Char('j') => {

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -123,8 +123,8 @@ impl<'a> Sort<'a> {
             for (idx, item) in order
                 .iter()
                 .enumerate()
-                .skip(paging.current_page() * paging.capacity())
-                .take(paging.capacity())
+                .skip(paging.current_page * paging.capacity)
+                .take(paging.capacity)
             {
                 render.sort_prompt_item(&self.items[*item], checked, sel == idx)?;
             }
@@ -160,9 +160,9 @@ impl<'a> Sort<'a> {
                     }
                 }
                 Key::ArrowLeft | Key::Char('h') => {
-                    if paging.active() {
+                    if paging.active {
                         let old_sel = sel;
-                        let old_page = paging.current_page();
+                        let old_page = paging.current_page;
 
                         sel = paging.previous_page();
                         
@@ -182,14 +182,14 @@ impl<'a> Sort<'a> {
                     }
                 }
                 Key::ArrowRight | Key::Char('l') => {
-                    if paging.active() {
+                    if paging.active {
                         let old_sel = sel;
-                        let old_page = paging.current_page();
+                        let old_page = paging.current_page;
 
                         sel = paging.next_page();
 
                         if checked {
-                            let indexes: Vec<_> = if old_page == paging.pages() - 1 {
+                            let indexes: Vec<_> = if old_page == paging.pages - 1 {
                                 let indexes1: Vec<_> = (old_sel..self.items.len()).collect();
                                 let indexes2: Vec<_> = vec![0];
                                 [indexes1, indexes2].concat()
@@ -231,7 +231,7 @@ impl<'a> Sort<'a> {
 
             paging.update(sel)?;
 
-            if paging.active() {
+            if paging.active {
                 render.clear()?;
             } else {
                 render.clear_preserve_prompt(&size_vec)?;

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -53,6 +53,10 @@ impl<'a> Sort<'a> {
     }
 
     /// Enables or disables paging
+    #[deprecated(
+        since = "0.9.0",
+        note = "Activating paging has no effect anymore. Paging will be activated automatically if needed."
+    )]
     pub fn paged(&mut self, val: bool) -> &mut Sort<'a> {
         self.paged = val;
         self

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -109,7 +109,7 @@ impl<'a> Sort<'a> {
         }
 
         let mut render = TermThemeRenderer::new(term, self.theme);
-        let mut paging = Paging::new(term, &self.items);
+        let mut paging = Paging::new(term, self.items.len());
         let mut sel = 0;
 
         let mut size_vec = Vec::new();

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -99,8 +99,8 @@ impl<'a> Sort<'a> {
             ));
         }
 
-        let mut render = TermThemeRenderer::new(term, self.theme);
         let mut paging = Paging::new(term, self.items.len());
+        let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = 0;
 
         let mut size_vec = Vec::new();

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -1,6 +1,9 @@
 use std::{io, ops::Rem};
 
-use crate::{Paging, theme::{SimpleTheme, TermThemeRenderer, Theme}};
+use crate::{
+    theme::{SimpleTheme, TermThemeRenderer, Theme},
+    Paging,
+};
 
 use console::{Key, Term};
 
@@ -91,7 +94,6 @@ impl<'a> Sort<'a> {
 
     /// Like [interact](#method.interact) but allows a specific terminal to be set.
     pub fn interact_on(&self, term: &Term) -> io::Result<Vec<usize>> {
-
         if self.items.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -112,7 +114,7 @@ impl<'a> Sort<'a> {
 
         let mut order: Vec<_> = (0..self.items.len()).collect();
         let mut checked: bool = false;
-        
+
         term.hide_cursor()?;
 
         loop {
@@ -165,7 +167,7 @@ impl<'a> Sort<'a> {
                         let old_page = paging.current_page;
 
                         sel = paging.previous_page();
-                        
+
                         if checked {
                             let indexes: Vec<_> = if old_page == 0 {
                                 let indexes1: Vec<_> = (0..=old_sel).rev().collect();

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -50,15 +50,6 @@ impl<'a> Sort<'a> {
         }
     }
 
-    /// Enables or disables paging
-    #[deprecated(
-        since = "0.9.0",
-        note = "Activating paging has no effect anymore. Paging will be activated automatically if needed."
-    )]
-    pub fn paged(&mut self, _val: bool) -> &mut Sort<'a> {
-        self
-    }
-
     /// Sets the clear behavior of the menu.
     ///
     /// The default is to clear the menu after user interaction.

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -26,7 +26,6 @@ pub struct Sort<'a> {
     prompt: Option<String>,
     clear: bool,
     theme: &'a dyn Theme,
-    paged: bool,
 }
 
 impl<'a> Default for Sort<'a> {
@@ -48,7 +47,6 @@ impl<'a> Sort<'a> {
             clear: true,
             prompt: None,
             theme,
-            paged: false,
         }
     }
 
@@ -57,8 +55,7 @@ impl<'a> Sort<'a> {
         since = "0.9.0",
         note = "Activating paging has no effect anymore. Paging will be activated automatically if needed."
     )]
-    pub fn paged(&mut self, val: bool) -> &mut Sort<'a> {
-        self.paged = val;
+    pub fn paged(&mut self, _val: bool) -> &mut Sort<'a> {
         self
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -697,6 +697,13 @@ impl<'a> TermThemeRenderer<'a> {
         Ok(())
     }
 
+    fn write_paging_info(&mut self, paging_info: (usize, usize)) -> io::Result<()> {
+        self.write_formatted_str(|_this, buf| {
+            write!(buf, "[Page {}/{}] ", paging_info.0, paging_info.1)
+        })?;
+        Ok(())
+    }
+
     pub fn error(&mut self, err: &str) -> io::Result<()> {
         self.write_formatted_line(|this, buf| this.theme.format_error(buf, err))
     }
@@ -752,14 +759,11 @@ impl<'a> TermThemeRenderer<'a> {
         prompt: &str,
         paging_info: Option<(usize, usize)>,
     ) -> io::Result<()> {
-        self.write_formatted_prompt(|this, buf| {
-            
-            if let Some(paging_info) = paging_info {
-                write!(buf, "[Page {}/{}] ", paging_info.0, paging_info.1)?
-            }
+        if let Some(paging_info) = paging_info {
+            self.write_paging_info(paging_info)?;
+        }
 
-            this.theme.format_select_prompt(buf, prompt)
-        })
+        self.write_formatted_prompt(|this, buf| this.theme.format_select_prompt(buf, prompt))
     }
 
     pub fn select_prompt_selection(&mut self, prompt: &str, sel: &str) -> io::Result<()> {
@@ -774,15 +778,16 @@ impl<'a> TermThemeRenderer<'a> {
         })
     }
 
-    pub fn multi_select_prompt(&mut self, prompt: &str, paging_info: Option<(usize, usize)>) -> io::Result<()> {
-        self.write_formatted_prompt(|this, buf| {
-            
-            if let Some(paging_info) = paging_info {
-                write!(buf, "[Page {}/{}] ", paging_info.0, paging_info.1)?
-            }
-            
-            this.theme.format_multi_select_prompt(buf, prompt)
-        })
+    pub fn multi_select_prompt(
+        &mut self,
+        prompt: &str,
+        paging_info: Option<(usize, usize)>,
+    ) -> io::Result<()> {
+        if let Some(paging_info) = paging_info {
+            self.write_paging_info(paging_info)?;
+        }
+
+        self.write_formatted_prompt(|this, buf| this.theme.format_multi_select_prompt(buf, prompt))
     }
 
     pub fn multi_select_prompt_selection(&mut self, prompt: &str, sel: &[&str]) -> io::Result<()> {
@@ -804,7 +809,14 @@ impl<'a> TermThemeRenderer<'a> {
         })
     }
 
-    pub fn sort_prompt(&mut self, prompt: &str) -> io::Result<()> {
+    pub fn sort_prompt(
+        &mut self,
+        prompt: &str,
+        paging_info: Option<(usize, usize)>,
+    ) -> io::Result<()> {
+        if let Some(paging_info) = paging_info {
+            self.write_paging_info(paging_info)?;
+        }
         self.write_formatted_prompt(|this, buf| this.theme.format_sort_prompt(buf, prompt))
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -747,19 +747,18 @@ impl<'a> TermThemeRenderer<'a> {
         })
     }
 
-    pub fn select_prompt(&mut self, prompt: &str) -> io::Result<()> {
-        self.write_formatted_prompt(|this, buf| this.theme.format_select_prompt(buf, prompt))
-    }
-
-    pub fn select_prompt_paged(
+    pub fn select_prompt(
         &mut self,
         prompt: &str,
-        page: usize,
-        pages: usize,
+        paging_info: Option<(usize, usize)>,
     ) -> io::Result<()> {
         self.write_formatted_prompt(|this, buf| {
-            this.theme
-                .format_select_prompt_paged(buf, prompt, page, pages)
+            
+            if let Some(paging_info) = paging_info {
+                write!(buf, "[Page {}/{}] ", paging_info.0, paging_info.1)?
+            }
+
+            this.theme.format_select_prompt(buf, prompt)
         })
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -106,7 +106,7 @@ pub trait Theme {
     }
 
     /// Formats a select prompt with pages.
-    fn format_select_prompt_with_pages(&self, f: &mut dyn fmt::Write, prompt: &str, page: usize, pages: usize) -> fmt::Result {
+    fn format_select_prompt_paged(&self, f: &mut dyn fmt::Write, prompt: &str, page: usize, pages: usize) -> fmt::Result {
         self.format_prompt(f, prompt)?;
         write!(f, " (Page {}/{})", page, pages)
     }
@@ -745,13 +745,13 @@ impl<'a> TermThemeRenderer<'a> {
         self.write_formatted_prompt(|this, buf| this.theme.format_select_prompt(buf, prompt))
     }
 
-    pub fn select_prompt_with_pages(
+    pub fn select_prompt_paged(
         &mut self,
         prompt: &str,
         page: usize,
         pages: usize,
     ) -> io::Result<()> {
-        self.write_formatted_prompt(|this, buf| this.theme.format_select_prompt_with_pages(buf, prompt, page, pages))
+        self.write_formatted_prompt(|this, buf| this.theme.format_select_prompt_paged(buf, prompt, page, pages))
     }
 
     pub fn select_prompt_selection(&mut self, prompt: &str, sel: &str) -> io::Result<()> {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -830,10 +830,6 @@ impl<'a> TermThemeRenderer<'a> {
             }
         }
 
-        if new_height < self.term.size().0 as usize {
-            new_height += self.term.size().0 as usize - new_height;
-        }
-
         self.term.clear_last_lines(new_height)?;
         self.height = 0;
         Ok(())

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -685,7 +685,7 @@ impl<'a> TermThemeRenderer<'a> {
         Ok(())
     }
 
-    fn write_paging_info_to_buf(
+    fn write_paging_info(
         buf: &mut dyn fmt::Write,
         paging_info: (usize, usize),
     ) -> fmt::Result {
@@ -751,7 +751,7 @@ impl<'a> TermThemeRenderer<'a> {
             this.theme.format_select_prompt(buf, prompt)?;
 
             if let Some(paging_info) = paging_info {
-                TermThemeRenderer::write_paging_info_to_buf(buf, paging_info)?;
+                TermThemeRenderer::write_paging_info(buf, paging_info)?;
             }
 
             Ok(())
@@ -779,7 +779,7 @@ impl<'a> TermThemeRenderer<'a> {
             this.theme.format_multi_select_prompt(buf, prompt)?;
 
             if let Some(paging_info) = paging_info {
-                TermThemeRenderer::write_paging_info_to_buf(buf, paging_info)?;
+                TermThemeRenderer::write_paging_info(buf, paging_info)?;
             }
 
             Ok(())
@@ -814,7 +814,7 @@ impl<'a> TermThemeRenderer<'a> {
             this.theme.format_sort_prompt(buf, prompt)?;
 
             if let Some(paging_info) = paging_info {
-                TermThemeRenderer::write_paging_info_to_buf(buf, paging_info)?;
+                TermThemeRenderer::write_paging_info(buf, paging_info)?;
             }
 
             Ok(())

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -685,10 +685,7 @@ impl<'a> TermThemeRenderer<'a> {
         Ok(())
     }
 
-    fn write_paging_info(
-        buf: &mut dyn fmt::Write,
-        paging_info: (usize, usize),
-    ) -> fmt::Result {
+    fn write_paging_info(buf: &mut dyn fmt::Write, paging_info: (usize, usize)) -> fmt::Result {
         write!(buf, " [Page {}/{}] ", paging_info.0, paging_info.1)
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -685,11 +685,11 @@ impl<'a> TermThemeRenderer<'a> {
         Ok(())
     }
 
-    fn write_paging_info(&mut self, paging_info: (usize, usize)) -> io::Result<()> {
-        self.write_formatted_str(|_this, buf| {
-            write!(buf, "[Page {}/{}] ", paging_info.0, paging_info.1)
-        })?;
-        Ok(())
+    fn write_paging_info_to_buf(
+        buf: &mut dyn fmt::Write,
+        paging_info: (usize, usize),
+    ) -> fmt::Result {
+        write!(buf, " [Page {}/{}] ", paging_info.0, paging_info.1)
     }
 
     pub fn error(&mut self, err: &str) -> io::Result<()> {
@@ -747,11 +747,15 @@ impl<'a> TermThemeRenderer<'a> {
         prompt: &str,
         paging_info: Option<(usize, usize)>,
     ) -> io::Result<()> {
-        if let Some(paging_info) = paging_info {
-            self.write_paging_info(paging_info)?;
-        }
+        self.write_formatted_prompt(|this, buf| {
+            this.theme.format_select_prompt(buf, prompt)?;
 
-        self.write_formatted_prompt(|this, buf| this.theme.format_select_prompt(buf, prompt))
+            if let Some(paging_info) = paging_info {
+                TermThemeRenderer::write_paging_info_to_buf(buf, paging_info)?;
+            }
+
+            Ok(())
+        })
     }
 
     pub fn select_prompt_selection(&mut self, prompt: &str, sel: &str) -> io::Result<()> {
@@ -771,11 +775,15 @@ impl<'a> TermThemeRenderer<'a> {
         prompt: &str,
         paging_info: Option<(usize, usize)>,
     ) -> io::Result<()> {
-        if let Some(paging_info) = paging_info {
-            self.write_paging_info(paging_info)?;
-        }
+        self.write_formatted_prompt(|this, buf| {
+            this.theme.format_multi_select_prompt(buf, prompt)?;
 
-        self.write_formatted_prompt(|this, buf| this.theme.format_multi_select_prompt(buf, prompt))
+            if let Some(paging_info) = paging_info {
+                TermThemeRenderer::write_paging_info_to_buf(buf, paging_info)?;
+            }
+
+            Ok(())
+        })
     }
 
     pub fn multi_select_prompt_selection(&mut self, prompt: &str, sel: &[&str]) -> io::Result<()> {
@@ -802,10 +810,15 @@ impl<'a> TermThemeRenderer<'a> {
         prompt: &str,
         paging_info: Option<(usize, usize)>,
     ) -> io::Result<()> {
-        if let Some(paging_info) = paging_info {
-            self.write_paging_info(paging_info)?;
-        }
-        self.write_formatted_prompt(|this, buf| this.theme.format_sort_prompt(buf, prompt))
+        self.write_formatted_prompt(|this, buf| {
+            this.theme.format_sort_prompt(buf, prompt)?;
+
+            if let Some(paging_info) = paging_info {
+                TermThemeRenderer::write_paging_info_to_buf(buf, paging_info)?;
+            }
+
+            Ok(())
+        })
     }
 
     pub fn sort_prompt_selection(&mut self, prompt: &str, sel: &[&str]) -> io::Result<()> {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -105,6 +105,12 @@ pub trait Theme {
         self.format_prompt(f, prompt)
     }
 
+    /// Formats a select prompt with pages.
+    fn format_select_prompt_with_pages(&self, f: &mut dyn fmt::Write, prompt: &str, page: usize, pages: usize) -> fmt::Result {
+        self.format_prompt(f, prompt)?;
+        write!(f, " (Page {}/{})", page, pages)
+    }
+
     /// Formats a select prompt after selection.
     #[inline]
     fn format_select_prompt_selection(
@@ -737,6 +743,15 @@ impl<'a> TermThemeRenderer<'a> {
 
     pub fn select_prompt(&mut self, prompt: &str) -> io::Result<()> {
         self.write_formatted_prompt(|this, buf| this.theme.format_select_prompt(buf, prompt))
+    }
+
+    pub fn select_prompt_with_pages(
+        &mut self,
+        prompt: &str,
+        page: usize,
+        pages: usize,
+    ) -> io::Result<()> {
+        self.write_formatted_prompt(|this, buf| this.theme.format_select_prompt_with_pages(buf, prompt, page, pages))
     }
 
     pub fn select_prompt_selection(&mut self, prompt: &str, sel: &str) -> io::Result<()> {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -830,6 +830,11 @@ impl<'a> TermThemeRenderer<'a> {
                 new_height += 1;
             }
         }
+
+        if new_height < self.term.size().0 as usize {
+            new_height += self.term.size().0 as usize - new_height;
+        }
+
         self.term.clear_last_lines(new_height)?;
         self.height = 0;
         Ok(())

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -106,7 +106,13 @@ pub trait Theme {
     }
 
     /// Formats a select prompt with pages.
-    fn format_select_prompt_paged(&self, f: &mut dyn fmt::Write, prompt: &str, page: usize, pages: usize) -> fmt::Result {
+    fn format_select_prompt_paged(
+        &self,
+        f: &mut dyn fmt::Write,
+        prompt: &str,
+        page: usize,
+        pages: usize,
+    ) -> fmt::Result {
         self.format_prompt(f, prompt)?;
         write!(f, " (Page {}/{})", page, pages)
     }
@@ -751,7 +757,10 @@ impl<'a> TermThemeRenderer<'a> {
         page: usize,
         pages: usize,
     ) -> io::Result<()> {
-        self.write_formatted_prompt(|this, buf| this.theme.format_select_prompt_paged(buf, prompt, page, pages))
+        self.write_formatted_prompt(|this, buf| {
+            this.theme
+                .format_select_prompt_paged(buf, prompt, page, pages)
+        })
     }
 
     pub fn select_prompt_selection(&mut self, prompt: &str, sel: &str) -> io::Result<()> {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -774,8 +774,15 @@ impl<'a> TermThemeRenderer<'a> {
         })
     }
 
-    pub fn multi_select_prompt(&mut self, prompt: &str) -> io::Result<()> {
-        self.write_formatted_prompt(|this, buf| this.theme.format_multi_select_prompt(buf, prompt))
+    pub fn multi_select_prompt(&mut self, prompt: &str, paging_info: Option<(usize, usize)>) -> io::Result<()> {
+        self.write_formatted_prompt(|this, buf| {
+            
+            if let Some(paging_info) = paging_info {
+                write!(buf, "[Page {}/{}] ", paging_info.0, paging_info.1)?
+            }
+            
+            this.theme.format_multi_select_prompt(buf, prompt)
+        })
     }
 
     pub fn multi_select_prompt_selection(&mut self, prompt: &str, sel: &[&str]) -> io::Result<()> {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -105,18 +105,6 @@ pub trait Theme {
         self.format_prompt(f, prompt)
     }
 
-    /// Formats a select prompt with pages.
-    fn format_select_prompt_paged(
-        &self,
-        f: &mut dyn fmt::Write,
-        prompt: &str,
-        page: usize,
-        pages: usize,
-    ) -> fmt::Result {
-        self.format_prompt(f, prompt)?;
-        write!(f, " (Page {}/{})", page, pages)
-    }
-
     /// Formats a select prompt after selection.
     #[inline]
     fn format_select_prompt_selection(


### PR DESCRIPTION
This addresses #125 

The following things have been addressed:

* I extracted all the functions regarding the paging functionality into an own module to reduce code redundancy
* The module detects if paging is needed and (de)activates paging accordingly
* The module is able to update terminal information via an `update()` function. This allows the rendering to adjust to terminal resizing. (But since the `match term.read_key()?` seems to block the rendering loop, the healing will only be achieved after the next key press)
* All prompts that are related to item lists (except `fuzzy-select` for now) are adjusted to use the new paging module.
    * The prompt rendering functions have an additional parameter to be able to print the paging information

Currently the whole thing behaves like this when the terminal is resized:

![fix_paging](https://user-images.githubusercontent.com/6370295/131265455-dbaa1ee6-6ab9-4c9c-be4c-b5415bf35f81.gif)
