### PR TITLE
Chore: bump minimum stable Rust version to 1.51

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
         include:
           - os: macos-latest
             target: x86_64-apple-darwin
-            rust: 1.40.0
+            rust: 1.51.0
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            rust: 1.40.0
+            rust: 1.51.0
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
-            rust: 1.40.0
+            rust: 1.51.0
           - os: windows-latest
             target: i686-pc-windows-msvc
-            rust: 1.40.0
+            rust: 1.51.0
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            rust: 1.40.0
+            rust: 1.51.0
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             rust: stable


### PR DESCRIPTION
The `zeroize` crate now uses `const` generics for the [Zeroize trait](https://docs.rs/zeroize/1.4.1/zeroize/trait.Zeroize.html#impl-Zeroize-4). Since this feature is only available in [Rust 1.51 and above](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#const-generics-mvp), the automated testing (which was previously set to Rust 1.40) will always fail to compile. Thus, this PR bumps up the minimum stable Rust version to 1.51, which should finally allow tests to compile.