### PR TITLE
Refactor: treat `password` module as an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,15 @@ documentation = "https://docs.rs/dialoguer"
 readme = "README.md"
 
 [features]
-default = ["editor", "history"]
+default = ["editor", "history", "password"]
 editor = ["tempfile"]
 fuzzy-select = ["fuzzy-matcher"]
 history = []
+password = ["zeroize"]
 
 [dependencies]
 console = "0.14.1"
 lazy_static = "1"
 tempfile = { version = "3", optional = true }
-zeroize = "1.1.1"
+zeroize = { version = "1.1.1", optional = true }
 fuzzy-matcher = { version = "0.3.7", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,15 @@ pub use edit::Editor;
 #[cfg(feature = "history")]
 pub use history::History;
 pub use prompts::{
-    confirm::Confirm, input::Input, multi_select::MultiSelect, password::Password, select::Select,
-    sort::Sort,
+    confirm::Confirm, input::Input, multi_select::MultiSelect, select::Select, sort::Sort,
 };
 pub use validate::Validator;
 
 #[cfg(feature = "fuzzy-select")]
 pub use prompts::fuzzy_select::FuzzySelect;
+
+#[cfg(feature = "password")]
+pub use prompts::password::Password;
 
 #[cfg(feature = "editor")]
 mod edit;

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -157,10 +157,7 @@ impl<'a> FuzzySelect<'a> {
             // Renders all matching items, from best match to worst.
             filtered_list.sort_unstable_by(|(_, s1), (_, s2)| s2.cmp(&s1));
 
-            for (idx, (item, _)) in filtered_list
-                .iter()
-                .enumerate()
-            {
+            for (idx, (item, _)) in filtered_list.iter().enumerate() {
                 render.select_prompt_item(item, idx == sel)?;
                 term.flush()?;
             }

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -365,7 +365,7 @@ where
             if chars.is_empty() {
                 if let Some(ref default) = self.default {
                     if let Some(ref mut validator) = self.validator {
-                        if let Some(err) = validator(&default) {
+                        if let Some(err) = validator(default) {
                             render.error(&err)?;
                             continue;
                         }
@@ -448,7 +448,7 @@ where
             if input.is_empty() {
                 if let Some(ref default) = self.default {
                     if let Some(ref mut validator) = self.validator {
-                        if let Some(err) = validator(&default) {
+                        if let Some(err) = validator(default) {
                             render.error(&err)?;
                             continue;
                         }

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -3,9 +3,11 @@
 pub mod confirm;
 pub mod input;
 pub mod multi_select;
-pub mod password;
 pub mod select;
 pub mod sort;
 
 #[cfg(feature = "fuzzy-select")]
 pub mod fuzzy_select;
+
+#[cfg(feature = "password")]
+pub mod password;

--- a/src/prompts/password.rs
+++ b/src/prompts/password.rs
@@ -89,7 +89,7 @@ impl<'a> Password<'a> {
             let password = Zeroizing::new(self.prompt_password(&mut render, &self.prompt)?);
 
             if let Some((ref prompt, ref err)) = self.confirmation_prompt {
-                let pw2 = Zeroizing::new(self.prompt_password(&mut render, &prompt)?);
+                let pw2 = Zeroizing::new(self.prompt_password(&mut render, prompt)?);
 
                 if *password == *pw2 {
                     render.clear()?;


### PR DESCRIPTION
This PR continues the work done on #120. However, instead of disabling `zeroize` (which implies insecure inputs), this approach disables the `password` module altogether. As discussed in #120, we must enforce that the user must have either a **secure** password input or no password input at all—"all or nothing", so to speak.

For backwards-compatibility, the `password` feature is enabled by default.