### PR TITLE
Define unified interface for selecting/sorting prompts and changes as follows ↓

### DIFF
--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -111,19 +111,22 @@ impl<'a> Confirm<'a> {
 
     /// Enables user interaction and returns the result.
     ///
-    /// If the user confirms the result is `true`, `false` if declines or default (configured in [default](#method.default)) if pushes enter.
-    /// Otherwise function discards input waiting for valid one.
-    ///
     /// The dialog is rendered on stderr.
+    ///
+    /// Result contains `bool` if user answered "yes" or "no" or `default` (configured in [default](#method.default)) if pushes enter.
+    /// This unlike [interact_opt](#method.interact_opt) does not allow to quit with 'Esc' or 'q'.
+    #[inline]
     pub fn interact(&self) -> io::Result<bool> {
         self.interact_on(&Term::stderr())
     }
 
     /// Enables user interaction and returns the result.
     ///
-    /// This method is similar to [interact_on_opt](#method.interact_on_opt) except for the fact that it does not allow selection of the terminal.
     /// The dialog is rendered on stderr.
-    /// Result contains `Some(bool)` if user answered "yes" or "no" or `None` if user cancelled with 'Esc' or 'q'.
+    ///
+    /// Result contains `Some(bool)` if user answered "yes" or "no" or `Some(default)` (configured in [default](#method.default)) if pushes enter,
+    /// or `None` if user cancelled with 'Esc' or 'q'.
+    #[inline]
     pub fn interact_opt(&self) -> io::Result<Option<bool>> {
         self.interact_on_opt(&Term::stderr())
     }
@@ -143,6 +146,7 @@ impl<'a> Confirm<'a> {
     /// #   Ok(())
     /// # }
     /// ```
+    #[inline]
     pub fn interact_on(&self, term: &Term) -> io::Result<bool> {
         self._interact_on(term, false)?
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Quit not allowed in this case"))
@@ -167,6 +171,7 @@ impl<'a> Confirm<'a> {
     ///     Ok(())
     /// }
     /// ```
+    #[inline]
     pub fn interact_on_opt(&self, term: &Term) -> io::Result<Option<bool>> {
         self._interact_on(term, true)
     }

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -97,28 +97,34 @@ impl<'a> FuzzySelect<'a> {
 
     /// Enables user interaction and returns the result.
     ///
-    /// The index of the selected item.
+    /// The user can select the items using enter and the index of selected item will be returned.
     /// The dialog is rendered on stderr.
+    /// Result contains `index` of selected item if user hit 'Enter'.
+    /// This unlike [interact_opt](#method.interact_opt) does not allow to quit with 'Esc' or 'q'.
+    #[inline]
     pub fn interact(&self) -> io::Result<usize> {
         self.interact_on(&Term::stderr())
     }
 
     /// Enables user interaction and returns the result.
     ///
-    /// The index of the selected item. None if the user
-    /// cancelled with Esc or 'q'.
+    /// The user can select the items using enter and the index of selected item will be returned.
     /// The dialog is rendered on stderr.
+    /// Result contains `Some(index)` if user hit 'Enter' or `None` if user cancelled with 'Esc' or 'q'.
+    #[inline]
     pub fn interact_opt(&self) -> io::Result<Option<usize>> {
         self.interact_on_opt(&Term::stderr())
     }
 
     /// Like `interact` but allows a specific terminal to be set.
+    #[inline]
     pub fn interact_on(&self, term: &Term) -> io::Result<usize> {
         self._interact_on(term, false)?
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Quit not allowed in this case"))
     }
 
     /// Like `interact` but allows a specific terminal to be set.
+    #[inline]
     pub fn interact_on_opt(&self, term: &Term) -> io::Result<Option<usize>> {
         self._interact_on(term, true)
     }

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -168,18 +168,21 @@ impl<'a> Select<'a> {
 
     /// Enables user interaction and returns the result.
     ///
-    /// Similar to [interact_on](#method.interact_on) except for the fact that it does not allow selection of the terminal.
+    /// The user can select the items with the space bar or enter and the index of selected item will be returned.
     /// The dialog is rendered on stderr.
-    /// Result contains index of a selected item.
+    /// Result contains `Vec<index>` if user selected one of items using 'Enter'.
+    /// This unlike [interact_opt](#method.interact_opt) does not allow to quit with 'Esc' or 'q'.
+    #[inline]
     pub fn interact(&self) -> io::Result<usize> {
         self.interact_on(&Term::stderr())
     }
 
     /// Enables user interaction and returns the result.
     ///
-    /// This method is similar to [interact_on_opt](#method.interact_on_opt) except for the fact that it does not allow selection of the terminal.
+    /// The user can select the items with the space bar or enter and the index of selected item will be returned.
     /// The dialog is rendered on stderr.
-    /// Result contains `Some(index)` if user selected one of items or `None` if user cancelled with 'Esc' or 'q'.
+    /// Result contains `Some(index)` if user selected one of items using 'Enter' or `None` if user cancelled with 'Esc' or 'q'.
+    #[inline]
     pub fn interact_opt(&self) -> io::Result<Option<usize>> {
         self.interact_on_opt(&Term::stderr())
     }
@@ -202,6 +205,7 @@ impl<'a> Select<'a> {
     ///     Ok(())
     /// }
     ///```
+    #[inline]
     pub fn interact_on(&self, term: &Term) -> io::Result<usize> {
         self._interact_on(term, false)?
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Quit not allowed in this case"))
@@ -222,7 +226,7 @@ impl<'a> Select<'a> {
     ///
     ///     match selection {
     ///         Some(position) => println!("User selected option at index {}", position),
-    ///         None => println!("User did not select anything")
+    ///         None => println!("User did not select anything or exited using Esc or q")
     ///     }
     ///
     ///     Ok(())
@@ -289,9 +293,10 @@ impl<'a> Select<'a> {
                     if allow_quit {
                         if self.clear {
                             term.clear_last_lines(self.items.len())?;
-                            term.show_cursor()?;
-                            term.flush()?;
                         }
+
+                        term.show_cursor()?;
+                        term.flush()?;
 
                         return Ok(None);
                     }

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -86,14 +86,76 @@ impl<'a> Sort<'a> {
 
     /// Enables user interaction and returns the result.
     ///
-    /// The user can order the items with the space bar and the arrows.
-    /// On enter the ordered list will be returned.
+    /// The user can order the items with the space bar and the arrows. On enter ordered list of the incides of items will be returned.
+    /// The dialog is rendered on stderr.
+    /// Result contains `Vec<index>` if user hit 'Enter'.
+    /// This unlike [interact_opt](#method.interact_opt) does not allow to quit with 'Esc' or 'q'.
+    #[inline]
     pub fn interact(&self) -> io::Result<Vec<usize>> {
         self.interact_on(&Term::stderr())
     }
 
+    /// Enables user interaction and returns the result.
+    ///
+    /// The user can order the items with the space bar and the arrows. On enter ordered list of the incides of items will be returned.
+    /// The dialog is rendered on stderr.
+    /// Result contains `Some(Vec<index>)` if user hit 'Enter' or `None` if user cancelled with 'Esc' or 'q'.
+    #[inline]
+    pub fn interact_opt(&self) -> io::Result<Option<Vec<usize>>> {
+        self.interact_on_opt(&Term::stderr())
+    }
+
     /// Like [interact](#method.interact) but allows a specific terminal to be set.
+    ///
+    /// ## Examples
+    ///```rust,no_run
+    /// use dialoguer::Select;
+    /// use console::Term;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let selections = Sort::new()
+    ///         .item("Option A")
+    ///         .item("Option B")
+    ///         .interact_on(&Term::stderr())?;
+    ///
+    ///     println!("User sorted options as indices {:?}", selections);
+    ///
+    ///     Ok(())
+    /// }
+    ///```
+    #[inline]
     pub fn interact_on(&self, term: &Term) -> io::Result<Vec<usize>> {
+        self._interact_on(term, false)?
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Quit not allowed in this case"))
+    }
+
+    /// Like [interact_opt](#method.interact_opt) but allows a specific terminal to be set.
+    ///
+    /// ## Examples
+    /// ```rust,no_run
+    /// use dialoguer::Select;
+    /// use console::Term;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let selections = MultiSelect::new()
+    ///         .item("Option A")
+    ///         .item("Option B")
+    ///         .interact_on_opt(&Term::stdout())?;
+    ///
+    ///     match selections {
+    ///         Some(positions) => println!("User sorted options as indices {:?}", positions),
+    ///         None => println!("User exited using Esc or q")
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    #[inline]
+    pub fn interact_on_opt(&self, term: &Term) -> io::Result<Option<Vec<usize>>> {
+        self._interact_on(term, true)
+    }
+
+    fn _interact_on(&self, term: &Term, allow_quit: bool) -> io::Result<Option<Vec<usize>>> {
         if self.items.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -208,7 +270,18 @@ impl<'a> Sort<'a> {
                 Key::Char(' ') => {
                     checked = !checked;
                 }
-                // TODO: Key::Escape
+                Key::Escape | Key::Char('q') => {
+                    if allow_quit {
+                        if self.clear {
+                            term.clear_last_lines(self.items.len())?;
+                        }
+
+                        term.show_cursor()?;
+                        term.flush()?;
+
+                        return Ok(None);
+                    }
+                }
                 Key::Enter => {
                     if self.clear {
                         render.clear()?;
@@ -226,7 +299,7 @@ impl<'a> Sort<'a> {
                     term.show_cursor()?;
                     term.flush()?;
 
-                    return Ok(order);
+                    return Ok(Some(order));
                 }
                 _ => {}
             }


### PR DESCRIPTION
Overview of the changes:

* Properly define unified interface (`interact` | `interact_opt` | `interact_on` | `interact_on_opt`) on all the select/sorting variants.
* Return `Ok(None)` when multi-select is quit using `Esc` or `q`, instead of default values provided, so the consumer of library know when user quit and when used `Enter`.
* Properly provide `#[inline]` to those interact functions, to depend on `_interact_on`, previously were only on 1 of 4 in select.rs's funciton and not present in any function in fuzzy_select.rs for some reason.
* Unify the documentation.
* Add examples which were missing from `interact_on` and `interact_on_opt` on `multi-select` and `sort`.
