### PR TITLE
Add map method for changing inputted value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ lazy_static = "1"
 tempfile = { version = "3", optional = true }
 zeroize = { version = "1.1.1", optional = true }
 fuzzy-matcher = { version = "0.3.7", optional = true }
+
+[dev-dependencies]
+regex = "1.5.4"

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,4 +1,5 @@
 use dialoguer::{theme::ColorfulTheme, Input};
+use regex::Regex;
 
 fn main() {
     let input: String = Input::with_theme(&ColorfulTheme::default())
@@ -10,10 +11,17 @@ fn main() {
 
     let mail: String = Input::with_theme(&ColorfulTheme::default())
         .with_prompt("Your email")
+        .map(|mut input: String| {
+            if !input.contains('@') {
+                input += "@example.com";
+            }
+            input
+        })
         .validate_with({
             let mut force = None;
             move |input: &String| -> Result<(), &str> {
-                if input.contains('@') || force.as_ref().map_or(false, |old| old == input) {
+                let address_regex = Regex::new(r"^\S+@\S+\.\S+$").unwrap();
+                if address_regex.is_match(input) || force.as_ref().map_or(false, |old| old == input) {
                     Ok(())
                 } else {
                     force = Some(input.clone());


### PR DESCRIPTION
The motivation for this feature is almost same as doc comment of `map` method.

Although my need is sufficed by this PR, the implementation still has some design issues.

### Probably `mutate` method is necessary

I think it is very common usage for `map` method to appending some suffix to the inputted `String`. Writing a mutator instead of a mapper makes this task easy a bit because return value can be omitted.

### Execution order of mappers and validators

Imagine the following code

```
let value = Input::new()
    .validate(v1)
    .map(m)
    .validate(v2)
    .interact_text()
    .unwrap();
```

The user of `dialoguer` surely expect that `v1` validates `input` (the raw inputted value) and `v2` validates `m(input)`. However, in my implementation, both `v1` and `v2` validate `m(input)`.

To achieve this, mappers, mutators and validators should be treated as a unified "transformer" type, whose type is `FnMut(T) -> Result<T, Error>`.

### Mapping to a different type

There is no reason to restrict return type of mappers to the same type of input.

To achieve this, map's signature should be

```
pub fn map<U>(self, mut mapper: impl FnMut(T) -> U + 'a) -> Input<'a, U>
```

I think it is very misleading that only `map` method takes `self` and other ones takes `&mut self`, so it is good choice to change `Input` into [a consuming builder](https://doc.rust-lang.org/1.0.0/style/ownership/builders.html#consuming-builders:). However this is a huge breaking change for `dialoguer`.