### PR TITLE
fuzzy_select: enable paging

### DIFF
--- a/examples/fuzzypaging.rs
+++ b/examples/fuzzypaging.rs
@@ -1,0 +1,54 @@
+use dialoguer::{
+    console::{Style, Term},
+    theme::ColorfulTheme,
+    FuzzySelect,
+};
+
+fn main() {
+    let selections = &[
+        "Ice Cream",
+        "Vanilla Cupcake",
+        "Chocolate Muffin",
+        "A Pile of sweet, sweet mustard",
+        "Carrots",
+        "Peas",
+        "Pistacio",
+        "Mustard",
+        "Cream",
+        "Banana",
+        "Chocolate",
+        "Flakes",
+        "Corn",
+        "Cake",
+        "Tarte",
+        "Cheddar",
+        "Vanilla",
+        "Hazelnut",
+        "Flour",
+        "Sugar",
+        "Salt",
+        "Potato",
+        "French Fries",
+        "Pizza",
+        "Mousse au chocolat",
+        "Brown sugar",
+        "Blueberry",
+        "Burger",
+    ];
+
+    let theme = ColorfulTheme {
+        active_item_style: Style::new().for_stderr().on_green().black(),
+        ..Default::default()
+    };
+
+    let selection = FuzzySelect::with_theme(&theme)
+        .with_prompt("Pick your flavor")
+        .default(0)
+        .items(&selections[..])
+        .interact_opt()
+        .unwrap();
+
+    if let Some(sel) = selection {
+        println!("Enjoy your {}!", selections[sel]);
+    };
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -714,10 +714,17 @@ impl<'a> TermThemeRenderer<'a> {
         prompt: &str,
         search_term: &str,
         cursor_pos: usize,
+        paging_info: Option<(usize, usize)>,
     ) -> io::Result<()> {
         self.write_formatted_prompt(|this, buf| {
             this.theme
-                .format_fuzzy_select_prompt(buf, prompt, search_term, cursor_pos)
+                .format_fuzzy_select_prompt(buf, prompt, search_term, cursor_pos)?;
+
+            if let Some(paging_info) = paging_info {
+                TermThemeRenderer::write_paging_info(buf, paging_info)?;
+            }
+
+            Ok(())
         })
     }
 


### PR DESCRIPTION
Seems there  are some drawing issues in `fuzzy_select` with an item size exceeding the terminal  window size which is due to it not yet supporting paging.
I added paging according to how it is integrated in `select` but had to update `pages` (due to the filtering) and force `active` (so that the first lines aren't removed).