### PR TITLE
fix: properly clear term when paging

### DIFF
--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -266,6 +266,8 @@ impl MultiSelect<'_> {
                     if allow_quit {
                         if self.clear {
                             render.clear()?;
+                        } else {
+                            term.clear_last_lines(paging.capacity)?;
                         }
 
                         term.show_cursor()?;

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -278,7 +278,9 @@ impl Select<'_> {
                 Key::Escape | Key::Char('q') => {
                     if allow_quit {
                         if self.clear {
-                            term.clear_last_lines(self.items.len())?;
+                            render.clear()?;
+                        } else {
+                            term.clear_last_lines(paging.capacity)?;
                         }
 
                         term.show_cursor()?;

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -277,7 +277,9 @@ impl Sort<'_> {
                 Key::Escape | Key::Char('q') => {
                     if allow_quit {
                         if self.clear {
-                            term.clear_last_lines(self.items.len())?;
+                            render.clear()?;
+                        } else {
+                            term.clear_last_lines(paging.capacity)?;
                         }
 
                         term.show_cursor()?;


### PR DESCRIPTION
Follow up to #144

Ensure to properly clear the terminal when paging to a `max_length` less than `self.items`