### PR TITLE
feat: support optionally disabling the report after interaction

### DIFF
--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -21,6 +21,7 @@ use console::{Key, Term};
 /// ```
 pub struct Confirm<'a> {
     prompt: String,
+    report: bool,
     default: Option<bool>,
     show_default: bool,
     wait_for_newline: bool,
@@ -44,6 +45,14 @@ impl Confirm<'_> {
     /// Sets the confirm prompt.
     pub fn with_prompt<S: Into<String>>(&mut self, prompt: S) -> &mut Self {
         self.prompt = prompt.into();
+        self
+    }
+
+    /// Indicates whether or not to report the chosen selection after interaction.
+    ///
+    /// The default is to report the chosen selection.
+    pub fn report(&mut self, val: bool) -> &mut Self {
+        self.report = val;
         self
     }
 
@@ -226,7 +235,9 @@ impl Confirm<'_> {
         }
 
         term.clear_line()?;
-        render.confirm_prompt_selection(&self.prompt, rv)?;
+        if self.report {
+            render.confirm_prompt_selection(&self.prompt, rv)?;
+        }
         term.show_cursor()?;
         term.flush()?;
 
@@ -254,6 +265,7 @@ impl<'a> Confirm<'a> {
     pub fn with_theme(theme: &'a dyn Theme) -> Self {
         Self {
             prompt: "".into(),
+            report: true,
             default: None,
             show_default: true,
             wait_for_newline: false,

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -37,6 +37,7 @@ pub struct FuzzySelect<'a> {
     default: usize,
     items: Vec<String>,
     prompt: String,
+    report: bool,
     clear: bool,
     theme: &'a dyn Theme,
 }
@@ -89,6 +90,14 @@ impl FuzzySelect<'_> {
     /// the fuzzy selection.
     pub fn with_prompt<S: Into<String>>(&mut self, prompt: S) -> &mut Self {
         self.prompt = prompt.into();
+        self
+    }
+
+    /// Indicates whether to report the selected value after interaction.
+    ///
+    /// The default is to report the selection.
+    pub fn report(&mut self, val: bool) -> &mut Self {
+        self.report = val;
         self
     }
 
@@ -204,7 +213,10 @@ impl FuzzySelect<'_> {
                         render.clear()?;
                     }
 
-                    render.input_prompt_selection(self.prompt.as_str(), &filtered_list[sel].0)?;
+                    if self.report {
+                        render
+                            .input_prompt_selection(self.prompt.as_str(), &filtered_list[sel].0)?;
+                    }
 
                     let sel_string = filtered_list[sel].0;
                     let sel_string_pos_in_items =
@@ -240,6 +252,7 @@ impl<'a> FuzzySelect<'a> {
             default: !0,
             items: vec![],
             prompt: "".into(),
+            report: true,
             clear: true,
             theme,
         }

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -39,6 +39,7 @@ use console::{Key, Term};
 /// ```
 pub struct Input<'a, T> {
     prompt: String,
+    report: bool,
     default: Option<T>,
     show_default: bool,
     initial_text: Option<String>,
@@ -66,6 +67,14 @@ impl<T> Input<'_, T> {
     /// Sets the input prompt.
     pub fn with_prompt<S: Into<String>>(&mut self, prompt: S) -> &mut Self {
         self.prompt = prompt.into();
+        self
+    }
+
+    /// Indicates whether to report the input value after interaction.
+    ///
+    /// The default is to report the input value.
+    pub fn report(&mut self, val: bool) -> &mut Self {
+        self.report = val;
         self
     }
 
@@ -110,6 +119,7 @@ impl<'a, T> Input<'a, T> {
     pub fn with_theme(theme: &'a dyn Theme) -> Self {
         Self {
             prompt: "".into(),
+            report: true,
             default: None,
             show_default: true,
             initial_text: None,
@@ -403,7 +413,9 @@ where
                         }
                     }
 
-                    render.input_prompt_selection(&self.prompt, &default.to_string())?;
+                    if self.report {
+                        render.input_prompt_selection(&self.prompt, &default.to_string())?;
+                    }
                     term.flush()?;
                     return Ok(default.clone());
                 } else if !self.permit_empty {
@@ -425,7 +437,9 @@ where
                         history.write(&value);
                     }
 
-                    render.input_prompt_selection(&self.prompt, &input)?;
+                    if self.report {
+                        render.input_prompt_selection(&self.prompt, &input)?;
+                    }
                     term.flush()?;
 
                     return Ok(value);
@@ -492,7 +506,9 @@ where
                         }
                     }
 
-                    render.input_prompt_selection(&self.prompt, &default.to_string())?;
+                    if self.report {
+                        render.input_prompt_selection(&self.prompt, &default.to_string())?;
+                    }
                     term.flush()?;
                     return Ok(default.clone());
                 } else if !self.permit_empty {
@@ -509,7 +525,9 @@ where
                         }
                     }
 
-                    render.input_prompt_selection(&self.prompt, &input)?;
+                    if self.report {
+                        render.input_prompt_selection(&self.prompt, &input)?;
+                    }
                     term.flush()?;
 
                     return Ok(value);

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -111,7 +111,7 @@ impl MultiSelect<'_> {
     /// Prefaces the menu with a prompt.
     ///
     /// By default, when a prompt is set the system also prints out a confirmation after
-    /// the selection. You can opt-out of this with [report](#method.report).
+    /// the selection. You can opt-out of this with [`report`](#method.report).
     pub fn with_prompt<S: Into<String>>(&mut self, prompt: S) -> &mut Self {
         self.prompt = Some(prompt.into());
         self

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -25,6 +25,7 @@ pub struct MultiSelect<'a> {
     defaults: Vec<bool>,
     items: Vec<String>,
     prompt: Option<String>,
+    report: bool,
     clear: bool,
     max_length: Option<usize>,
     theme: &'a dyn Theme,
@@ -109,10 +110,18 @@ impl MultiSelect<'_> {
 
     /// Prefaces the menu with a prompt.
     ///
-    /// When a prompt is set the system also prints out a confirmation after
-    /// the selection.
+    /// By default, when a prompt is set the system also prints out a confirmation after
+    /// the selection. You can opt-out of this with [report](#method.report).
     pub fn with_prompt<S: Into<String>>(&mut self, prompt: S) -> &mut Self {
         self.prompt = Some(prompt.into());
+        self
+    }
+
+    /// Indicates whether to report the selected values after interaction.
+    ///
+    /// The default is to report the selections.
+    pub fn report(&mut self, val: bool) -> &mut Self {
+        self.report = val;
         self
     }
 
@@ -280,19 +289,21 @@ impl MultiSelect<'_> {
                     }
 
                     if let Some(ref prompt) = self.prompt {
-                        let selections: Vec<_> = checked
-                            .iter()
-                            .enumerate()
-                            .filter_map(|(idx, &checked)| {
-                                if checked {
-                                    Some(self.items[idx].as_str())
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect();
+                        if self.report {
+                            let selections: Vec<_> = checked
+                                .iter()
+                                .enumerate()
+                                .filter_map(|(idx, &checked)| {
+                                    if checked {
+                                        Some(self.items[idx].as_str())
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect();
 
-                        render.multi_select_prompt_selection(prompt, &selections[..])?;
+                            render.multi_select_prompt_selection(prompt, &selections[..])?;
+                        }
                     }
 
                     term.show_cursor()?;
@@ -328,6 +339,7 @@ impl<'a> MultiSelect<'a> {
             defaults: vec![],
             clear: true,
             prompt: None,
+            report: true,
             max_length: None,
             theme,
         }

--- a/src/prompts/password.rs
+++ b/src/prompts/password.rs
@@ -21,6 +21,7 @@ use zeroize::Zeroizing;
 /// ```
 pub struct Password<'a> {
     prompt: String,
+    report: bool,
     theme: &'a dyn Theme,
     allow_empty_password: bool,
     confirmation_prompt: Option<(String, String)>,
@@ -43,6 +44,14 @@ impl Password<'_> {
     /// Sets the password input prompt.
     pub fn with_prompt<S: Into<String>>(&mut self, prompt: S) -> &mut Self {
         self.prompt = prompt.into();
+        self
+    }
+
+    /// Indicates whether to report confirmation after interaction.
+    ///
+    /// The default is to report.
+    pub fn report(&mut self, val: bool) -> &mut Self {
+        self.report = val;
         self
     }
 
@@ -85,7 +94,9 @@ impl Password<'_> {
 
                 if *password == *pw2 {
                     render.clear()?;
-                    render.password_prompt_selection(&self.prompt)?;
+                    if self.report {
+                        render.password_prompt_selection(&self.prompt)?;
+                    }
                     term.flush()?;
                     return Ok((*password).clone());
                 }
@@ -93,7 +104,9 @@ impl Password<'_> {
                 render.error(err)?;
             } else {
                 render.clear()?;
-                render.password_prompt_selection(&self.prompt)?;
+                if self.report {
+                    render.password_prompt_selection(&self.prompt)?;
+                }
                 term.flush()?;
 
                 return Ok((*password).clone());
@@ -122,6 +135,7 @@ impl<'a> Password<'a> {
     pub fn with_theme(theme: &'a dyn Theme) -> Self {
         Self {
             prompt: "".into(),
+            report: true,
             theme,
             allow_empty_password: false,
             confirmation_prompt: None,

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -38,6 +38,7 @@ pub struct Select<'a> {
     default: usize,
     items: Vec<String>,
     prompt: Option<String>,
+    report: bool,
     clear: bool,
     theme: &'a dyn Theme,
     max_length: Option<usize>,
@@ -130,8 +131,8 @@ impl Select<'_> {
 
     /// Sets the select prompt.
     ///
-    /// When a prompt is set the system also prints out a confirmation after
-    /// the selection.
+    /// By default, when a prompt is set the system also prints out a confirmation after
+    /// the selection. You can opt-out of this with [report](#method.report).
     ///
     /// ## Examples
     /// ```rust,no_run
@@ -149,6 +150,15 @@ impl Select<'_> {
     /// ```
     pub fn with_prompt<S: Into<String>>(&mut self, prompt: S) -> &mut Self {
         self.prompt = Some(prompt.into());
+        self.report = true;
+        self
+    }
+
+    /// Indicates whether to report the selected value after interaction.
+    ///
+    /// The default is to report the selection.
+    pub fn report(&mut self, val: bool) -> &mut Self {
+        self.report = val;
         self
     }
 
@@ -312,7 +322,9 @@ impl Select<'_> {
                     }
 
                     if let Some(ref prompt) = self.prompt {
-                        render.select_prompt_selection(prompt, &self.items[sel])?;
+                        if self.report {
+                            render.select_prompt_selection(prompt, &self.items[sel])?;
+                        }
                     }
 
                     term.show_cursor()?;
@@ -358,6 +370,7 @@ impl<'a> Select<'a> {
             default: !0,
             items: vec![],
             prompt: None,
+            report: false,
             clear: true,
             max_length: None,
             theme,

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -132,7 +132,7 @@ impl Select<'_> {
     /// Sets the select prompt.
     ///
     /// By default, when a prompt is set the system also prints out a confirmation after
-    /// the selection. You can opt-out of this with [report](#method.report).
+    /// the selection. You can opt-out of this with [`report`](#method.report).
     ///
     /// ## Examples
     /// ```rust,no_run

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -83,7 +83,7 @@ impl Sort<'_> {
     /// Prefaces the menu with a prompt.
     ///
     /// By default, when a prompt is set the system also prints out a confirmation after
-    /// the selection. You can opt-out of this with [report](#method.report).
+    /// the selection. You can opt-out of this with [`report`](#method.report).
     pub fn with_prompt<S: Into<String>>(&mut self, prompt: S) -> &mut Self {
         self.prompt = Some(prompt.into());
         self

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -27,6 +27,7 @@ use console::{Key, Term};
 pub struct Sort<'a> {
     items: Vec<String>,
     prompt: Option<String>,
+    report: bool,
     clear: bool,
     max_length: Option<usize>,
     theme: &'a dyn Theme,
@@ -81,10 +82,18 @@ impl Sort<'_> {
 
     /// Prefaces the menu with a prompt.
     ///
-    /// When a prompt is set the system also prints out a confirmation after
-    /// the selection.
+    /// By default, when a prompt is set the system also prints out a confirmation after
+    /// the selection. You can opt-out of this with [report](#method.report).
     pub fn with_prompt<S: Into<String>>(&mut self, prompt: S) -> &mut Self {
         self.prompt = Some(prompt.into());
+        self
+    }
+
+    /// Indicates whether to report the selected order after interaction.
+    ///
+    /// The default is to report the selected order.
+    pub fn report(&mut self, val: bool) -> &mut Self {
+        self.report = val;
         self
     }
 
@@ -292,12 +301,14 @@ impl Sort<'_> {
                     }
 
                     if let Some(ref prompt) = self.prompt {
-                        let list: Vec<_> = order
-                            .iter()
-                            .enumerate()
-                            .map(|(_, item)| self.items[*item].as_str())
-                            .collect();
-                        render.sort_prompt_selection(prompt, &list[..])?;
+                        if self.report {
+                            let list: Vec<_> = order
+                                .iter()
+                                .enumerate()
+                                .map(|(_, item)| self.items[*item].as_str())
+                                .collect();
+                            render.sort_prompt_selection(prompt, &list[..])?;
+                        }
                     }
 
                     term.show_cursor()?;
@@ -326,6 +337,7 @@ impl<'a> Sort<'a> {
             items: vec![],
             clear: true,
             prompt: None,
+            report: true,
             max_length: None,
             theme,
         }


### PR DESCRIPTION
Sometimes, the whole prompt sneakily fizzing out is useful. Interact, sure.. but afterwards, clean everything up.