### PR TITLE
fix(doc): unlinked ref

### DIFF
--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -95,7 +95,7 @@ impl<T> Input<'_, T> {
 
     /// Disables or enables the default value display.
     ///
-    /// The default behaviour is to append [`default`] to the prompt to tell the
+    /// The default behaviour is to append [`default`](#method.default) to the prompt to tell the
     /// user what is the default value.
     ///
     /// This method does not affect existance of default value, only its display in the prompt!


### PR DESCRIPTION
```console
cargo doc
 Documenting dialoguer v0.9.0 (/home/miraclx/projects/git/mitsuhiko/dialoguer)
warning: unresolved link to `default`
  --> src/prompts/input.rs:98:46
   |
98 |     /// The default behaviour is to append [`default`] to the prompt to tell the
   |                                              ^^^^^^^ no item named `default` in scope
   |
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: `dialoguer` (lib doc) generated 1 warning
```