### PR TITLE
put example behind conditional flag

### DIFF
--- a/examples/completion.rs
+++ b/examples/completion.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "completion")]
 use dialoguer::{theme::ColorfulTheme, Completion, Input};
 
 fn main() -> Result<(), std::io::Error> {


### PR DESCRIPTION
the 'completion' example returns import errors if the 'completion' feature is not used. This PR places the whole example behind this feature flag to prevent the import error