### PR TITLE
add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+name: Code Coverage
+
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: --all-features --tests --doc
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2.1.0


### PR DESCRIPTION
adds a coverage workflow using `codecov`.

Coverage in this repo is pretty low, so the intention would be for this workflow to be purely informational, and provide an opportunity to push PRs to at least *improve* coverage over time.