### PR TITLE
confirm: properly clear the terminal in case of a multi-line prompt string

### DIFF
--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -210,8 +210,10 @@ impl Confirm<'_> {
                         continue;
                     }
                 };
-
+                // `prompt` may be a multi-line string, hence we may need to clear more than the current line.
+                // `clear_last_lines` clears the n lines *before* the current line.
                 term.clear_line()?;
+                term.clear_last_lines(self.prompt.lines().count() - 1)?;
                 render.confirm_prompt(&self.prompt, value)?;
             }
         } else {
@@ -234,7 +236,10 @@ impl Confirm<'_> {
             }
         }
 
+        // `prompt` may be a multi-line string, hence we may need to clear more than the current line.
+        // `clear_last_lines` clears the n lines *before* the current line.
         term.clear_line()?;
+        term.clear_last_lines(self.prompt.lines().count() - 1)?;
         if self.report {
             render.confirm_prompt_selection(&self.prompt, rv)?;
         }


### PR DESCRIPTION
Need to clear the current line before clearing previous lines, otherwise a stray final line is left behind. Not sure why.
Fixes #165.

I'm not sure how to add a test. Happy to add one, if somebody can point me at how to do this.
Barring that, I tested this manually, for all four combinations of report={true,false} and wait_for_newline={true,false}.