### PR TITLE
Tell docs.rs to document all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,6 @@ required-features = ["completion"]
 
 [workspace.metadata.workspaces]
 no_individual_tags = true
+
+[package.metadata.docs.rs]
+ all-features = true


### PR DESCRIPTION
Docs.rs doesn't build optional features by default, and so e.g. `FuzzySelect` does not show up and cannot be searched for.

This change will tell it to build docs for every optional feature.