### PR TITLE
Handle selection items overflowing several times

### DIFF
--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -144,9 +144,9 @@ impl FuzzySelect<'_> {
         let mut sel = self.default;
 
         let mut size_vec = Vec::new();
-        for items in self.items.iter().as_slice() {
-            let size = &items.len();
-            size_vec.push(*size);
+        for item in self.items.iter().as_slice() {
+            // Formatting each item adds two more characters.
+            size_vec.push(item.len() + 2);
         }
 
         // Fuzzy matcher

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -143,11 +143,11 @@ impl FuzzySelect<'_> {
         let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = self.default;
 
-        let mut size_vec = Vec::new();
-        for item in self.items.iter().as_slice() {
+        let size_vec: Vec<_> = self.items.iter()
+            .flat_map(|i| i.split('\n'))
             // Formatting each item adds two more characters.
-            size_vec.push(item.len() + 2);
-        }
+            .map(|item| item.len() + 2)
+            .collect();
 
         // Fuzzy matcher
         let matcher = fuzzy_matcher::skim::SkimMatcherV2::default();

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -210,14 +210,14 @@ impl MultiSelect<'_> {
 
         let mut size_vec = Vec::new();
 
-        for items in self
+        for item in self
             .items
             .iter()
             .flat_map(|i| i.split('\n'))
             .collect::<Vec<_>>()
         {
-            let size = &items.len();
-            size_vec.push(*size);
+            // Formatting each item adds two more characters.
+            size_vec.push(item.len() + 2);
         }
 
         let mut checked: Vec<bool> = self.defaults.clone();

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -208,17 +208,11 @@ impl MultiSelect<'_> {
         let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = 0;
 
-        let mut size_vec = Vec::new();
-
-        for item in self
-            .items
-            .iter()
+        let size_vec: Vec<_> = self.items.iter()
             .flat_map(|i| i.split('\n'))
-            .collect::<Vec<_>>()
-        {
             // Formatting each item adds two more characters.
-            size_vec.push(item.len() + 2);
-        }
+            .map(|item| item.len() + 2)
+            .collect();
 
         let mut checked: Vec<bool> = self.defaults.clone();
 

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -247,17 +247,11 @@ impl Select<'_> {
         let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = self.default;
 
-        let mut size_vec = Vec::new();
-
-        for item in self
-            .items
-            .iter()
+        let size_vec: Vec<_> = self.items.iter()
             .flat_map(|i| i.split('\n'))
-            .collect::<Vec<_>>()
-        {
             // Formatting each item adds two more characters.
-            size_vec.push(item.len() + 2);
-        }
+            .map(|item| item.len() + 2)
+            .collect();
 
         term.hide_cursor()?;
 

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -249,14 +249,14 @@ impl Select<'_> {
 
         let mut size_vec = Vec::new();
 
-        for items in self
+        for item in self
             .items
             .iter()
             .flat_map(|i| i.split('\n'))
             .collect::<Vec<_>>()
         {
-            let size = &items.len();
-            size_vec.push(*size);
+            // Formatting each item adds two more characters.
+            size_vec.push(item.len() + 2);
         }
 
         term.hide_cursor()?;

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -181,12 +181,11 @@ impl Sort<'_> {
         let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = 0;
 
-        let mut size_vec = Vec::new();
-
-        for item in self.items.iter().as_slice() {
+        let size_vec: Vec<_> = self.items.iter()
+            .flat_map(|i| i.split('\n'))
             // Formatting each item adds two more characters.
-            size_vec.push(item.len() + 2);
-        }
+            .map(|item| item.len() + 2)
+            .collect();
 
         let mut order: Vec<_> = (0..self.items.len()).collect();
         let mut checked: bool = false;

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -183,9 +183,9 @@ impl Sort<'_> {
 
         let mut size_vec = Vec::new();
 
-        for items in self.items.iter().as_slice() {
-            let size = &items.len();
-            size_vec.push(*size);
+        for item in self.items.iter().as_slice() {
+            // Formatting each item adds two more characters.
+            size_vec.push(item.len() + 2);
         }
 
         let mut order: Vec<_> = (0..self.items.len()).collect();

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -846,9 +846,15 @@ impl<'a> TermThemeRenderer<'a> {
         Ok(())
     }
 
+    /// Clear all output after the last user prompt; leave the prompt behind.
+    ///
+    /// `size_vec` contains the lengths of all lines of output after the prompt.
     pub fn clear_preserve_prompt(&mut self, size_vec: &[usize]) -> io::Result<()> {
+        // Printing a selectable item (which should only take up one line)
+        // can yield several lines in the terminal: if the item is longer than the terminal.
+        // Take this into account, to fully clear all input after the prompt.
         let mut new_height = self.height;
-        //Check each item size, increment on finding an overflow
+        // Check each item size, increment if it overflows the terminal width.
         for size in size_vec {
             if *size > self.term.size().1 as usize {
                 new_height += 1;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -856,9 +856,8 @@ impl<'a> TermThemeRenderer<'a> {
         let mut new_height = self.height;
         // Check each item size, increment if it overflows the terminal width.
         for size in size_vec {
-            if *size > self.term.size().1 as usize {
-                new_height += 1;
-            }
+            let term_width = self.term.size().1 as usize;
+            new_height += *size / term_width;
         }
 
         self.term.clear_last_lines(new_height)?;


### PR DESCRIPTION
PR #14 was good, but not general enough: there were in fact two different bugs hiding. This PR
- documents the logic of the dix
- fixes an off-by-two error in the logic (which is easy to overlook; I only found that during manual testing),
- fixes clear_preserve_prompt to handle items overflowing several times
- cleans up the code slightly using iterators (happy to drop this commit if you prefer)
See individual commits for details.