### PR TITLE
Ignore Unknown keys

### DIFF
--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -390,12 +390,6 @@ where
                         }
                     }
                     Key::Enter => break,
-                    Key::Unknown => {
-                        return Err(io::Error::new(
-                            io::ErrorKind::NotConnected,
-                            "Not a terminal",
-                        ))
-                    }
                     _ => (),
                 }
             }


### PR DESCRIPTION
I found this issue when pressing the `Ctrl` key while using `Input`, which causes it to return `Err(Not a terminal)` under windows (but works fine on Linux). In this case, I was in the process of pressing `Ctrl + C` in order to terminate the program.

There are a few keystrokes which cause `console-rs` to produce `Unknown` keys when running under Windows. At the time of this commit this includes pressing the `Control` key, but also previously included `Shift` and `Alt`.
- https://github.com/console-rs/console/issues/83
- https://github.com/console-rs/console/issues/102

Pressing these keys under a *nix terminal does not appear to produce a "key" at all - rather the user must press a complete key chord before `Term::read_key()` will produce a result. 

Looking at the `console-rs` source, from what I can see that it produces an `Unknown` key under Windows in only two cases:
1. When the console is not "attended": https://github.com/console-rs/console/blob/master/src/term.rs#L274-L276
2. When the key code does not map to a known key in the Key enum: https://github.com/console-rs/console/blob/master/src/windows_term.rs#L337

Since `dialoguer` is already checking for non-attended consoles and executing an early return we can rule out needing to handle that scenario:
https://github.com/mitsuhiko/dialoguer/blob/f7d02321f5eda89c15b76ffbefbaebdd2c9f0bcb/src/prompts/input.rs#L276-L278

For the second scenario, it seems reasonable to ignore any "key" not recognized by `console-rs` for the purposes of the Input component.