### PR TITLE
Fix: [Fuzzy-Select] Apply active style to active item

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -340,7 +340,7 @@ impl Default for ColorfulTheme {
             #[cfg(feature = "fuzzy-select")]
             fuzzy_cursor_style: Style::new().for_stderr().black().on_white(),
             #[cfg(feature = "fuzzy-select")]
-            fuzzy_match_highlight_style: Style::new().for_stderr().bold().yellow(),
+            fuzzy_match_highlight_style: Style::new().for_stderr().bold(),
             inline_selections: true,
         }
     }
@@ -625,15 +625,24 @@ impl Theme for ColorfulTheme {
         matcher: &SkimMatcherV2,
         search_term: &str,
     ) -> fmt::Result {
-        write!(f, "{} ", if active { ">" } else { " " })?;
+        write!(f, "{} ", if active { &self.active_item_prefix } else { &self.inactive_item_prefix })?;
 
         if highlight_matches {
             if let Some((_score, indices)) = matcher.fuzzy_indices(text, &search_term) {
                 for (idx, c) in text.chars().into_iter().enumerate() {
                     if indices.contains(&idx) {
-                        write!(f, "{}", self.fuzzy_match_highlight_style.apply_to(c))?;
+                        if active {
+                            write!(f, "{}", self.active_item_style.apply_to(self.fuzzy_match_highlight_style.apply_to(c)))?;
+                        } else {
+                            // write!(f, "{}", self.fuzzy_match_highlight_style.apply_to(c).yellow())?;
+                            write!(f, "{}", self.fuzzy_match_highlight_style.apply_to(c))?;
+                        }
                     } else {
-                        write!(f, "{}", c)?;
+                        if active {
+                            write!(f, "{}", self.active_item_style.apply_to(c))?;
+                        } else {
+                            write!(f, "{}", c)?;
+                        }
                     }
                 }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -634,7 +634,6 @@ impl Theme for ColorfulTheme {
                         if active {
                             write!(f, "{}", self.active_item_style.apply_to(self.fuzzy_match_highlight_style.apply_to(c)))?;
                         } else {
-                            // write!(f, "{}", self.fuzzy_match_highlight_style.apply_to(c).yellow())?;
                             write!(f, "{}", self.fuzzy_match_highlight_style.apply_to(c))?;
                         }
                     } else {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -625,14 +625,27 @@ impl Theme for ColorfulTheme {
         matcher: &SkimMatcherV2,
         search_term: &str,
     ) -> fmt::Result {
-        write!(f, "{} ", if active { &self.active_item_prefix } else { &self.inactive_item_prefix })?;
+        write!(
+            f,
+            "{} ",
+            if active {
+                &self.active_item_prefix
+            } else {
+                &self.inactive_item_prefix
+            }
+        )?;
 
         if highlight_matches {
             if let Some((_score, indices)) = matcher.fuzzy_indices(text, &search_term) {
                 for (idx, c) in text.chars().into_iter().enumerate() {
                     if indices.contains(&idx) {
                         if active {
-                            write!(f, "{}", self.active_item_style.apply_to(self.fuzzy_match_highlight_style.apply_to(c)))?;
+                            write!(
+                                f,
+                                "{}",
+                                self.active_item_style
+                                    .apply_to(self.fuzzy_match_highlight_style.apply_to(c))
+                            )?;
                         } else {
                             write!(f, "{}", self.fuzzy_match_highlight_style.apply_to(c))?;
                         }


### PR DESCRIPTION
This fixes #195.

I decided to go for the bold-only option (No3 in https://github.com/mitsuhiko/dialoguer/issues/195#issuecomment-1121610065).