### PR TITLE
Home, End, Del operations for Input struct prompt

### DIFF
--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -443,7 +443,6 @@ where
                 self.initial_text = Some(String::from(""));
             }
 
-
             let input = chars.iter().collect::<String>();
 
             term.clear_line()?;

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -435,10 +435,6 @@ where
                     _ => (),
                 }
             }
-            // when you got initial text already
-            // and you deleted all the chars with backspace or del
-            // and then you press enter, the initial text will reapear
-            // so the initial modified to "" to not appear anymore
             if self.initial_text.is_some() && chars.is_empty() {
                 self.initial_text = Some(String::from(""));
             }

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -309,7 +309,7 @@ where
                     }
                     // press Del key to delete the char in front of the cursor
                     // cursor stays in the same position
-                    Key::Del if 0 <= position && position < chars.len() => {
+                    Key::Del if position < chars.len() => {
                         // first get the tail before deletion
                         let tail = chars[position + 1..].iter().collect::<String>();
                         // move visually 1 unit to right
@@ -317,6 +317,7 @@ where
                         // delete all the chars from right to the pos of cursor (which is to left side)
                         term.clear_chars(1)?;
                         chars.remove(position);
+
                         // append visually the tail to the user written text
                         term.write_str(&tail)?;
                         // move visually to the left length of tail; why ?
@@ -434,6 +435,15 @@ where
                     _ => (),
                 }
             }
+            // when you got initial text already
+            // and you deleted all the chars with backspace or del
+            // and then you press enter, the initial text will reapear
+            // so the initial modified to "" to not appear anymore
+            if self.initial_text.is_some() && chars.is_empty() {
+                self.initial_text = Some(String::from(""));
+            }
+
+
             let input = chars.iter().collect::<String>();
 
             term.clear_line()?;

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -286,10 +286,45 @@ where
                 term.write_str(initial)?;
                 chars = initial.chars().collect();
                 position = chars.len();
+                term.flush()?;
             }
 
             loop {
                 match term.read_key()? {
+                    // press Home key to go the beginning of the written text
+                    Key::Home if position != 0 => {
+                        // move visually to beginning
+                        term.move_cursor_left(position)?;
+                        position = 0;
+                        // refresh
+                        term.flush()?;
+                    }
+                    // press End key to go the end of the user written text
+                    Key::End if position != chars.len() => {
+                        // move visually to end based on current position
+                        term.move_cursor_right(chars.len() - position)?;
+                        position = chars.len();
+                        // refresh
+                        term.flush()?;
+                    }
+                    // press Del key to delete the char in front of the cursor
+                    // cursor stays in the same position
+                    Key::Del if 0 <= position && position < chars.len() => {
+                        // first get the tail before deletion
+                        let tail = chars[position + 1..].iter().collect::<String>();
+                        // move visually 1 unit to right
+                        term.move_cursor_right(1)?;
+                        // delete all the chars from right to the pos of cursor (which is to left side)
+                        term.clear_chars(1)?;
+                        chars.remove(position);
+                        // append visually the tail to the user written text
+                        term.write_str(&tail)?;
+                        // move visually to the left length of tail; why ?
+                        // because after write_str() the terminal cursor is at the end of user written text, then the cursor needs to go back from where it was on Del key press
+                        term.move_cursor_left(tail.len())?;
+                        // refresh
+                        term.flush()?;
+                    }
                     Key::Backspace if position > 0 => {
                         position -= 1;
                         chars.remove(position);

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -222,7 +222,7 @@ pub trait Theme {
         write!(f, "{} ", if active { ">" } else { " " })?;
 
         if highlight_matches {
-            if let Some((_score, indices)) = matcher.fuzzy_indices(text, &search_term) {
+            if let Some((_score, indices)) = matcher.fuzzy_indices(text, search_term) {
                 for (idx, c) in text.chars().into_iter().enumerate() {
                     if indices.contains(&idx) {
                         write!(f, "{}", style(c).for_stderr().bold())?;
@@ -258,7 +258,7 @@ pub trait Theme {
             write!(f, "{}{}{}", st_head, st_cursor, st_tail)
         } else {
             let cursor = "|".to_string();
-            write!(f, "{}{}", search_term.to_string(), cursor)
+            write!(f, "{}{}", search_term, cursor)
         }
     }
 }
@@ -636,7 +636,7 @@ impl Theme for ColorfulTheme {
         )?;
 
         if highlight_matches {
-            if let Some((_score, indices)) = matcher.fuzzy_indices(text, &search_term) {
+            if let Some((_score, indices)) = matcher.fuzzy_indices(text, search_term) {
                 for (idx, c) in text.chars().into_iter().enumerate() {
                     if indices.contains(&idx) {
                         if active {
@@ -649,12 +649,12 @@ impl Theme for ColorfulTheme {
                         } else {
                             write!(f, "{}", self.fuzzy_match_highlight_style.apply_to(c))?;
                         }
+                    } else if active {
+                        // since in lib.rs is deny clippy::all
+                        // the old else if was converted to this one
+                        write!(f, "{}", self.active_item_style.apply_to(c))?;
                     } else {
-                        if active {
-                            write!(f, "{}", self.active_item_style.apply_to(c))?;
-                        } else {
-                            write!(f, "{}", c)?;
-                        }
+                        write!(f, "{}", c)?;
                     }
                 }
 
@@ -700,7 +700,7 @@ impl Theme for ColorfulTheme {
                 f,
                 "{} {}{}",
                 &self.prompt_suffix,
-                search_term.to_string(),
+                search_term,
                 cursor
             )
         }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -650,8 +650,6 @@ impl Theme for ColorfulTheme {
                             write!(f, "{}", self.fuzzy_match_highlight_style.apply_to(c))?;
                         }
                     } else if active {
-                        // since in lib.rs is deny clippy::all
-                        // the old else if was converted to this one
                         write!(f, "{}", self.active_item_style.apply_to(c))?;
                     } else {
                         write!(f, "{}", c)?;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -696,13 +696,7 @@ impl Theme for ColorfulTheme {
             )
         } else {
             let cursor = self.fuzzy_cursor_style.apply_to(" ");
-            write!(
-                f,
-                "{} {}{}",
-                &self.prompt_suffix,
-                search_term,
-                cursor
-            )
+            write!(f, "{} {}{}", &self.prompt_suffix, search_term, cursor)
         }
     }
 }


### PR DESCRIPTION
Hello again.

In this PR I've added
- `Home, End, Del operations` for `Input` struct prompt.
- an empty `rustfmt.toml` to specify that rustfmt should format with default settings (why is that? because I have a `~/.config/rustfmt/rustfmt.toml` on my system)
- fixes to the source code because clippy wasnt very happy.


I've run:
- `cargo build --all-features`
- `cargo clippy --all-features`
- `cargo test --lib`
- `cargo fmt -- --check`

all successes.


I've tested the feature from my cli and worked on most (almost all) cases, so I think would work.

Cant wait for response!

Thanks in advance.