### PR TITLE
Enable customization of number of rows for FuzzySelect

### DIFF
--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -172,7 +172,10 @@ impl FuzzySelect<'_> {
 
         // Subtract -2 because we need space to render the prompt.
         let visible_term_rows = (term.size().0 as usize).max(3) - 2;
-        let visible_term_rows = self.visible_term_rows.unwrap_or(visible_term_rows);
+        let visible_term_rows = self
+            .visible_term_rows
+            .unwrap_or(visible_term_rows)
+            .min(visible_term_rows);
         // Variable used to determine if we need to scroll through the list.
         let mut starting_row = 0;
 

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -40,7 +40,7 @@ pub struct FuzzySelect<'a> {
     report: bool,
     clear: bool,
     highlight_matches: bool,
-    visible_term_rows: Option<usize>,
+    max_length: Option<usize>,
     theme: &'a dyn Theme,
 }
 
@@ -114,8 +114,8 @@ impl FuzzySelect<'_> {
     /// Sets the maximum number of visible options.
     ///
     /// The default is the height of the terminal minus 2.
-    pub fn with_visible_term_rows(&mut self, rows: usize) -> &mut Self {
-        self.visible_term_rows = Some(rows);
+    pub fn with_max_length(&mut self, rows: usize) -> &mut Self {
+        self.max_length = Some(rows);
         self
     }
 
@@ -173,7 +173,7 @@ impl FuzzySelect<'_> {
         // Subtract -2 because we need space to render the prompt.
         let visible_term_rows = (term.size().0 as usize).max(3) - 2;
         let visible_term_rows = self
-            .visible_term_rows
+            .max_length
             .unwrap_or(visible_term_rows)
             .min(visible_term_rows);
         // Variable used to determine if we need to scroll through the list.
@@ -305,7 +305,7 @@ impl<'a> FuzzySelect<'a> {
             report: true,
             clear: true,
             highlight_matches: true,
-            visible_term_rows: None,
+            max_length: None,
             theme,
         }
     }

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -111,7 +111,7 @@ impl FuzzySelect<'_> {
         self
     }
 
-    /// Sets the number of visible options.
+    /// Sets the maximum number of visible options.
     ///
     /// The default is the height of the terminal minus 2.
     pub fn with_visible_term_rows(&mut self, rows: usize) -> &mut Self {

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -40,6 +40,7 @@ pub struct FuzzySelect<'a> {
     report: bool,
     clear: bool,
     highlight_matches: bool,
+    visible_term_rows: Option<usize>,
     theme: &'a dyn Theme,
 }
 
@@ -110,6 +111,14 @@ impl FuzzySelect<'_> {
         self
     }
 
+    /// Sets the number of visible options.
+    ///
+    /// The default is the height of the terminal minus 2.
+    pub fn with_visible_term_rows(&mut self, rows: usize) -> &mut Self {
+        self.visible_term_rows = Some(rows);
+        self
+    }
+
     /// Enables user interaction and returns the result.
     ///
     /// The user can select the items using 'Enter' and the index of selected item will be returned.
@@ -163,6 +172,7 @@ impl FuzzySelect<'_> {
 
         // Subtract -2 because we need space to render the prompt.
         let visible_term_rows = (term.size().0 as usize).max(3) - 2;
+        let visible_term_rows = self.visible_term_rows.unwrap_or(visible_term_rows);
         // Variable used to determine if we need to scroll through the list.
         let mut starting_row = 0;
 
@@ -292,6 +302,7 @@ impl<'a> FuzzySelect<'a> {
             report: true,
             clear: true,
             highlight_matches: true,
+            visible_term_rows: None,
             theme,
         }
     }


### PR DESCRIPTION
Hi!

In this PR, I've made a small but useful extension to `FuzzySelect` that enables the user to decide how many options will be displayed at one time, rather than the default of the terminal height minus 2.

Example code:
```rust
FuzzySelect::with_theme(&ColorfulTheme::default())
                .with_prompt("What is your guess?")
                .with_visible_term_rows(5_usize)
                .items(word_slice)
                .report(true)
                .default(0)
                .interact()?;
```

Here's an example of how it looks with `visible_term_rows = 5`:

<img width="321" alt="image" src="https://user-images.githubusercontent.com/1293223/186335654-671660ec-8806-4219-807e-d179280efe8c.png">

I'm still somewhat new to Rust, let me know if there's any code style that can be improved.
