### PR TITLE
feat(fuzzy): implement multi-fuzzy-selection

### DIFF
--- a/examples/multi_fuzzy_select.rs
+++ b/examples/multi_fuzzy_select.rs
@@ -37,6 +37,7 @@ fn main() {
         .with_prompt("Pick your food")
         .items(&multiselected[..])
         .defaults(&defaults[..])
+        .max_length(10)
         .interact()
         .unwrap();
     if selections.is_empty() {

--- a/examples/multi_fuzzy_select.rs
+++ b/examples/multi_fuzzy_select.rs
@@ -1,0 +1,50 @@
+use dialoguer::{theme::ColorfulTheme, MultiFuzzySelect};
+
+fn main() {
+    let multiselected = &[
+        "Ice Cream",
+        "Vanilla Cupcake",
+        "Chocolate Muffin",
+        "A Pile of sweet, sweet mustard",
+        "Carrots",
+        "Peas",
+        "Pistacio",
+        "Mustard",
+        "Cream",
+        "Banana",
+        "Chocolate",
+        "Flakes",
+        "Corn",
+        "Cake",
+        "Tarte",
+        "Cheddar",
+        "Vanilla",
+        "Hazelnut",
+        "Flour",
+        "Sugar",
+        "Salt",
+        "Potato",
+        "French Fries",
+        "Pizza",
+        "Mousse au chocolat",
+        "Brown sugar",
+        "Blueberry",
+        "Burger",
+    ];
+
+    let defaults = &[false, false, true, false];
+    let selections = MultiFuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt("Pick your food")
+        .items(&multiselected[..])
+        .defaults(&defaults[..])
+        .interact()
+        .unwrap();
+    if selections.is_empty() {
+        println!("You did not select anything :(");
+    } else {
+        println!("You selected these things:");
+        for selection in selections {
+            println!("  {}", multiselected[selection]);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub use prompts::{
 pub use validate::Validator;
 
 #[cfg(feature = "fuzzy-select")]
-pub use prompts::fuzzy_select::FuzzySelect;
+pub use prompts::{fuzzy_select::FuzzySelect, multi_fuzzy_select::MultiFuzzySelect};
 
 #[cfg(feature = "password")]
 pub use prompts::password::Password;

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -138,13 +138,12 @@ impl FuzzySelect<'_> {
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Quit not allowed in this case"))
     }
 
-    /// Like `interact` but allows a specific terminal to be set.
+    /// Like `interact_opt` but allows a specific terminal to be set.
     #[inline]
     pub fn interact_on_opt(&self, term: &Term) -> io::Result<Option<usize>> {
         self._interact_on(term, true)
     }
 
-    /// Like `interact` but allows a specific terminal to be set.
     fn _interact_on(&self, term: &Term, allow_quit: bool) -> io::Result<Option<usize>> {
         let mut position = 0;
         let mut search_term = String::new();

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -8,6 +8,8 @@ pub mod sort;
 
 #[cfg(feature = "fuzzy-select")]
 pub mod fuzzy_select;
+#[cfg(feature = "fuzzy-select")]
+pub mod multi_fuzzy_select;
 
 #[cfg(feature = "password")]
 pub mod password;

--- a/src/prompts/multi_fuzzy_select.rs
+++ b/src/prompts/multi_fuzzy_select.rs
@@ -299,9 +299,12 @@ impl MultiFuzzySelect<'_> {
                     term.flush()?;
                 }
                 Key::Char(' ') => {
-                    let sel_string = filtered_list[sel].1;
-                    if let Some(sel_string_pos_in_items) =
-                        self.items.iter().position(|item| item.eq(sel_string))
+                    if let Some(sel_string_pos_in_items) = filtered_list
+                        .get(sel)
+                        .map(|selection| selection.1)
+                        .and_then(|sel_string| {
+                            self.items.iter().position(|item| item.eq(sel_string))
+                        })
                     {
                         checked[sel_string_pos_in_items] = !checked[sel_string_pos_in_items];
                     }

--- a/src/prompts/multi_fuzzy_select.rs
+++ b/src/prompts/multi_fuzzy_select.rs
@@ -185,7 +185,7 @@ impl MultiFuzzySelect<'_> {
 
         loop {
             render.clear()?;
-            render.fuzzy_select_prompt(self.prompt.as_str(), &search_term, position)?;
+            render.multi_fuzzy_select_prompt(self.prompt.as_str(), &search_term, position)?;
 
             // Maps all items to a tuple of item and its match score.
             let mut filtered_list = self

--- a/src/prompts/multi_fuzzy_select.rs
+++ b/src/prompts/multi_fuzzy_select.rs
@@ -277,7 +277,7 @@ impl MultiFuzzySelect<'_> {
                     let selected_items = checked
                         .into_iter()
                         .enumerate()
-                        .filter_map(|(idx, checked)| checked.then_some(idx))
+                        .filter_map(|(idx, checked)| checked.then(|| idx))
                         .collect::<Vec<_>>();
 
                     term.show_cursor()?;

--- a/src/prompts/multi_fuzzy_select.rs
+++ b/src/prompts/multi_fuzzy_select.rs
@@ -43,6 +43,7 @@ pub struct MultiFuzzySelect<'a> {
     report: bool,
     clear: bool,
     highlight_matches: bool,
+    max_length: Option<usize>,
     theme: &'a dyn Theme,
 }
 
@@ -121,6 +122,14 @@ impl MultiFuzzySelect<'_> {
         self
     }
 
+    /// Sets the maximum number of visible options.
+    ///
+    /// The default is the height of the terminal minus 2.
+    pub fn max_length(&mut self, rows: usize) -> &mut Self {
+        self.max_length = Some(rows);
+        self
+    }
+
     /// Enables user interaction and returns the result.
     ///
     /// The user can toggle the selection of the hovered item using 'Spacebar'.
@@ -176,6 +185,10 @@ impl MultiFuzzySelect<'_> {
 
         // Subtract -2 because we need space to render the prompt.
         let visible_term_rows = (term.size().0 as usize).max(3) - 2;
+        let visible_term_rows = self
+            .max_length
+            .map(|max_len| max_len.min(visible_term_rows))
+            .unwrap_or(visible_term_rows);
         // Variable used to determine if we need to scroll through the list.
         let mut starting_row = 0;
 
@@ -325,6 +338,7 @@ impl<'a> MultiFuzzySelect<'a> {
             report: true,
             clear: true,
             highlight_matches: true,
+            max_length: None,
             theme,
         }
     }

--- a/src/prompts/multi_fuzzy_select.rs
+++ b/src/prompts/multi_fuzzy_select.rs
@@ -280,8 +280,6 @@ impl MultiFuzzySelect<'_> {
                         .filter_map(|(idx, checked)| checked.then_some(idx))
                         .collect::<Vec<_>>();
 
-                    println!("{selected_items:?}");
-
                     term.show_cursor()?;
                     return Ok(selected_items);
                 }

--- a/src/prompts/multi_fuzzy_select.rs
+++ b/src/prompts/multi_fuzzy_select.rs
@@ -4,10 +4,9 @@ use fuzzy_matcher::FuzzyMatcher;
 use std::iter::repeat;
 use std::{io, ops::Rem};
 
-/// Renders a selection menu that user can fuzzy match to reduce set.
+/// Renders a multi selection menu that user can fuzzy match to reduce set.
 /// Selection/Deselection is done by pressing `Spacebar`.
 /// (Note that this restricts the user to only search non-spacebar characters)
-/// Finishing the selection is done by pressing `Enter`
 ///
 /// User can use fuzzy search to limit selectable items.
 /// Interaction returns `Vec` of indices of the selected items in the order they appear in `item` invocation or `items` slice.
@@ -29,12 +28,7 @@ use std::{io, ops::Rem};
 ///         .interact_on_opt(&Term::stderr())?;
 ///
 ///     match selection {
-///         Some(indices) => println!(
-///         "User selected items : {}", items.iter()
-///                                         .enumerate()
-///                                         .filter(|(idx, _)| indices.contains(idx))
-///                                         .map(|(_, item)| item)
-///                                         .collect::<Vec<_>>()),
+///         Some(indices) => println!("User selected items : {:?}", indices),
 ///         None => println!("User did not select anything")
 ///     }
 ///
@@ -129,9 +123,11 @@ impl MultiFuzzySelect<'_> {
 
     /// Enables user interaction and returns the result.
     ///
-    /// The user can select the items using 'Enter' and the index of selected item will be returned.
+    /// The user can toggle the selection of the hovered item using 'Spacebar'.
+    /// After the desired items are all toggled, the user can submit the selection by pressing
+    /// 'Enter' and the indices of the selected items will be returned.
     /// The dialog is rendered on stderr.
-    /// Result contains `index` of selected item if user hit 'Enter'.
+    /// Result contains `Vec<index>` of selected items if user hit 'Enter'.
     /// This unlike [interact_opt](#method.interact_opt) does not allow to quit with 'Esc' or 'q'.
     #[inline]
     pub fn interact(&self) -> io::Result<Vec<usize>> {
@@ -140,9 +136,11 @@ impl MultiFuzzySelect<'_> {
 
     /// Enables user interaction and returns the result.
     ///
-    /// The user can select the items using 'Enter' and the index of selected item will be returned.
+    /// The user can toggle the selection of the hovered item using 'Spacebar'.
+    /// After the desired items are all toggled, the user can submit the selection by pressing
+    /// 'Enter' and the indices of the selected items will be returned.
     /// The dialog is rendered on stderr.
-    /// Result contains `Some(index)` if user hit 'Enter' or `None` if user cancelled with 'Esc' or 'q'.
+    /// Result contains `Some(Vec<index>)` if user hit 'Enter' or `None` if user cancelled with 'Esc' or 'q'.
     #[inline]
     pub fn interact_opt(&self) -> io::Result<Vec<usize>> {
         self.interact_on_opt(&Term::stderr())
@@ -154,13 +152,12 @@ impl MultiFuzzySelect<'_> {
         self._interact_on(term, false)
     }
 
-    /// Like `interact` but allows a specific terminal to be set.
+    /// Like `interact_opt` but allows a specific terminal to be set.
     #[inline]
     pub fn interact_on_opt(&self, term: &Term) -> io::Result<Vec<usize>> {
         self._interact_on(term, true)
     }
 
-    /// Like `interact` but allows a specific terminal to be set.
     fn _interact_on(&self, term: &Term, allow_quit: bool) -> io::Result<Vec<usize>> {
         let mut position = 0;
         let mut search_term = String::new();
@@ -208,7 +205,7 @@ impl MultiFuzzySelect<'_> {
                 .skip(starting_row)
                 .take(visible_term_rows)
             {
-                render.fuzzy_select_multi_prompt_item(
+                render.multi_fuzzy_select_prompt_item(
                     item,
                     idx == sel,
                     checked[*item_idx],

--- a/src/prompts/multi_fuzzy_select.rs
+++ b/src/prompts/multi_fuzzy_select.rs
@@ -29,7 +29,12 @@ use std::{io, ops::Rem};
 ///         .interact_on_opt(&Term::stderr())?;
 ///
 ///     match selection {
-///         Some(index) => println!("User selected item : {}", items[index]),
+///         Some(indices) => println!(
+///         "User selected items : {}", items.iter()
+///                                         .enumerate()
+///                                         .filter(|(idx, _)| indices.contains(idx))
+///                                         .map(|(_, item)| item)
+///                                         .collect::<Vec<_>>()),
 ///         None => println!("User did not select anything")
 ///     }
 ///
@@ -84,6 +89,7 @@ impl MultiFuzzySelect<'_> {
     /// Add a single item to the fuzzy selector.
     pub fn item<T: ToString>(&mut self, item: T) -> &mut Self {
         self.items.push(item.to_string());
+        self.defaults.push(false);
         self
     }
 
@@ -91,6 +97,7 @@ impl MultiFuzzySelect<'_> {
     pub fn items<T: ToString>(&mut self, items: &[T]) -> &mut Self {
         for item in items {
             self.items.push(item.to_string());
+            self.defaults.push(false);
         }
         self
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -922,7 +922,7 @@ impl<'a> TermThemeRenderer<'a> {
     }
 
     #[cfg(feature = "fuzzy-select")]
-    pub fn fuzzy_select_multi_prompt_item(
+    pub fn multi_fuzzy_select_prompt_item(
         &mut self,
         text: &str,
         active: bool,


### PR DESCRIPTION
This commit includes a working example to showcase the feature.

Items are selected with spacebar and the selection is confirmed with enter.

---

Short background story:

I've been using the command line tool `glab` to work with my gitlab repos. There, some subcommands use a fuzzy-selection-search to select e.g. labels of issues. I found this feature very handy and wanted to use it for shell-scripts etc, but couldn't find a CLI tool or library that provides something like that. I hope you'll like it as much as I do!

To be fair, I have to mention, that the implementation of this feature has one flaw: You can't specifically search for some search term which includes spaces. But in practice that's almost never the case and in the few cases where you search terms with spaces, you can just skip them while typing in your search term and the fuzzy match algo will work great anyways.

I'm ready to make changes, if you request some.