### PR TITLE
MultiSelect: Implement checking and unchecking all

### DIFF
--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -271,6 +271,13 @@ impl MultiSelect<'_> {
                 Key::Char(' ') => {
                     checked[sel] = !checked[sel];
                 }
+                Key::Char('a') => {
+                    if checked.iter().all(|&item_checked| item_checked) {
+                        checked.fill(false);
+                    } else {
+                        checked.fill(true);
+                    }
+                }
                 Key::Escape | Key::Char('q') => {
                     if allow_quit {
                         if self.clear {


### PR DESCRIPTION
Closes #139.

Implement checking / unchecking all items in `MultiSelect` using the key <kbd>a</kbd>. Tested locally by running the `multi_select` example.

- The key <kbd>a</kbd> is used instead of the right arrow key, as seen in the screenshot of `gh` in the referred issue, because the right arrow key is already bound to page navigation.
- If all items are currently checked, uncheck all of them. Otherwise, all items are checked.