### PR TITLE
Adds the `full` feature convention for convenience

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,17 @@
 //! * Fuzzy select prompt
 //! * Other kind of prompts
 //! * Editor launching
+//!
+//! # Crate Features
+//!
+//! The following crate features are available:
+//! * `editor`: enables bindings to launch editor to edit strings
+//! * `fuzzy-select`: enables fuzzy select prompt
+//! * `history`: enables input prompts to be able to track history of inputs
+//! * `password`: enables password input prompt
+//! * `completion`: enables ability to implement custom tab-completion for input prompts
+//!
+//! By default `editor` and `password` are enabled.
 
 #![deny(clippy::all)]
 


### PR DESCRIPTION
I added a mention to the available features in the main documentation (since I needed to look in the Cargo.toml for them myself :sweat_smile: )  
In the second commit I added the `full` feature for convenience, because that seems to be a convention across popular crates. I'm happy to drop that commit and just keep the first one, if you prefer not to add that feature. :)