### PR TITLE
Added starting search term to `FuzzySelect`

### DIFF
--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -44,7 +44,7 @@ pub struct FuzzySelect<'a> {
     theme: &'a dyn Theme,
     /// Search string that a fuzzy search with start with.
     /// Defaults to an empty string.
-    search_term: String,
+    initial_text: String,
 }
 
 impl Default for FuzzySelect<'static> {
@@ -90,8 +90,8 @@ impl FuzzySelect<'_> {
     }
 
     /// Sets the search text that a fuzzy search starts with. 
-    pub fn search_term<S: Into<String>>(&mut self, search_term: S) -> &mut Self {
-        self.search_term = search_term.into();
+    pub fn with_initial_text<S: Into<String>>(&mut self, initial_text: S) -> &mut Self {
+        self.initial_text = initial_text.into();
         self
     }
 
@@ -165,8 +165,8 @@ impl FuzzySelect<'_> {
     /// Like `interact` but allows a specific terminal to be set.
     fn _interact_on(&self, term: &Term, allow_quit: bool) -> io::Result<Option<usize>> {
         // Place cursor at the end of the search term 
-        let mut position = self.search_term.len();
-        let mut search_term = self.search_term.to_owned();
+        let mut position = self.initial_text.len();
+        let mut search_term = self.initial_text.to_owned();
 
         let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = self.default;
@@ -317,7 +317,7 @@ impl<'a> FuzzySelect<'a> {
             highlight_matches: true,
             max_length: None,
             theme,
-            search_term: "".into(),
+            initial_text: "".into(),
         }
     }
 }

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -42,6 +42,9 @@ pub struct FuzzySelect<'a> {
     highlight_matches: bool,
     max_length: Option<usize>,
     theme: &'a dyn Theme,
+    /// Search string that a fuzzy search with start with.
+    /// Defaults to an empty string.
+    search_term: String,
 }
 
 impl Default for FuzzySelect<'static> {
@@ -83,6 +86,12 @@ impl FuzzySelect<'_> {
         for item in items {
             self.items.push(item.to_string());
         }
+        self
+    }
+
+    /// Sets the search text that a fuzzy search starts with. 
+    pub fn search_term<S: Into<String>>(&mut self, search_term: S) -> &mut Self {
+        self.search_term = search_term.into();
         self
     }
 
@@ -155,8 +164,9 @@ impl FuzzySelect<'_> {
 
     /// Like `interact` but allows a specific terminal to be set.
     fn _interact_on(&self, term: &Term, allow_quit: bool) -> io::Result<Option<usize>> {
-        let mut position = 0;
-        let mut search_term = String::new();
+        // Place cursor at the end of the search term 
+        let mut position = self.search_term.len();
+        let mut search_term = self.search_term.to_owned();
 
         let mut render = TermThemeRenderer::new(term, self.theme);
         let mut sel = self.default;
@@ -307,6 +317,7 @@ impl<'a> FuzzySelect<'a> {
             highlight_matches: true,
             max_length: None,
             theme,
+            search_term: "".into(),
         }
     }
 }


### PR DESCRIPTION
### Overview

Adds the ability to start a `FuzzySelect` from a non-empty string, by specifying an initial `search_term`.

```rust
let selections = &[
        "A Pile of sweet, sweet mustard",
        "Carrots",
        "Peas",
        "Pistacio",
        "Mustard",
        "Potato",
        "Pizza",
    ];
let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
        .with_prompt("Pick your flavor")
        .default(0)
        .search_term("P") // specify initial search term
        .items(&selections[..])
        .interact()
        .unwrap();
```

<img width="540" alt="image" src="https://user-images.githubusercontent.com/45083086/198856205-0730c376-40c8-4610-917e-1b4574a9e849.png">
