### PR TITLE
Always display current char when terminal is buffered

### DIFF
--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -219,8 +219,8 @@ impl FuzzySelect<'_> {
                     &matcher,
                     &search_term,
                 )?;
-                term.flush()?;
             }
+            term.flush()?;
 
             match (term.read_key()?, sel) {
                 (Key::Escape, _) if allow_quit => {


### PR DESCRIPTION
When a buffered terminal is used (like `Term::buffered_stderr()`), the current char won't always be printed if the user is typing a string that doesn't match anything.

This PR fixes this.

Also, moving the flush to outside the loop seems to be more efficient.