### PR TITLE
Flush terminal when initial text is used

### DIFF
--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -281,7 +281,6 @@ where
                     None
                 },
             )?;
-            term.flush()?;
 
             // Read input by keystroke so that we can suppress ascii control characters
             if !term.features().is_attended() {
@@ -298,6 +297,7 @@ where
                 chars = initial.chars().collect();
                 position = chars.len();
             }
+            term.flush()?;
 
             loop {
                 match term.read_key()? {


### PR DESCRIPTION
This is similar to https://github.com/mitsuhiko/dialoguer/pull/232

The issue only happens on buffered terminals