### PR TITLE
Fixed docs for select

### DIFF
--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -13,11 +13,7 @@ use console::{Key, Term};
 /// ## Examples
 ///
 /// ```rust,no_run
-/// use dialoguer::{
-///     Select,
-///     theme::ColorfulTheme
-/// };
-/// use console::Term;
+/// use dialoguer::{console::Term, theme::ColorfulTheme, Select};
 ///
 /// fn main() -> std::io::Result<()> {
 ///     let items = vec!["Item 1", "item 2"];
@@ -188,8 +184,7 @@ impl Select<'_> {
     ///
     /// ## Examples
     ///```rust,no_run
-    /// use dialoguer::Select;
-    /// use console::Term;
+    /// use dialoguer::{console::Term, Select};
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let selection = Select::new()
@@ -212,8 +207,7 @@ impl Select<'_> {
     ///
     /// ## Examples
     /// ```rust,no_run
-    /// use dialoguer::Select;
-    /// use console::Term;
+    /// use dialoguer::{console::Term, Select};
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let selection = Select::new()


### PR DESCRIPTION
In the docs for select (didn't have time to check the other functions) fixed the `use console::Term;` includes (which would cause an error).

Without explicitly installing `console` the docs would yield an error out of the box. Since you're re-exporting `console` it would make sense to take it from the main entry point.