### PR TITLE
Fix: Handle executable with spaces in name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ console = "0.15.0"
 tempfile = { version = "3", optional = true }
 zeroize = { version = "1.1.1", optional = true }
 fuzzy-matcher = { version = "0.3.7", optional = true }
+shell-words = "1.1.0"
 
 [[example]]
 name = "password"

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -99,9 +99,15 @@ impl Editor {
         let ts = fs::metadata(f.path())?.modified()?;
 
         let s: String = self.editor.clone().into_string().unwrap();
-        let mut iterator = s.split(' ');
-        let cmd = iterator.next().unwrap();
-        let args: Vec<&str> = iterator.collect();
+        let (cmd, args) = match shell_words::split(&s) {
+            Ok(mut parts) => {
+                let cmd = parts.remove(0);
+                (cmd, parts)
+            }
+            Err(_) => {
+                (s, vec![])
+            }
+        };
 
         let rv = process::Command::new(cmd)
             .args(args)


### PR DESCRIPTION
This was reported by a user of my project at https://github.com/arxanas/git-branchless/issues/718. In their case, they are running Windows, and the path to their executable naturally includes the substring `Program Files`, which has spaces in it. These spaces are not handled properly by `dialoguer`.

An alternative would be to offer an option to disable splitting on space, which would then allow the caller to manually parse the executable string on their own, in the event that it contains spaces; or we could add an alternative method to `Editor` (and update the internal state) so that we can construct it with a string that might contain both the executable and arguments, which will then do the space-splitting behavior.
