### PR TITLE
[Fuzzy-Select] Still apply active style if higlight is disabled

### DIFF
--- a/src/theme/colorful.rs
+++ b/src/theme/colorful.rs
@@ -393,7 +393,11 @@ impl Theme for ColorfulTheme {
             }
         }
 
-        write!(f, "{}", text)
+        if active {
+            write!(f, "{}", self.active_item_style.apply_to(text))
+        } else {
+            write!(f, "{}", text)
+        }
     }
 
     /// Formats a fuzzy-selectprompt after selection.


### PR DESCRIPTION
This syncs the active item behavior between a `Select` and a `FuzzySelect` in the case where highlighting in bold is disabled.

#199 only took care of the highlighting case
related to #312