### PR TITLE
feat: add show_hint option to Confirm prompt

### DIFF
--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -35,6 +35,7 @@ pub struct Confirm<'a> {
     show_default: bool,
     wait_for_newline: bool,
     theme: &'a dyn Theme,
+    show_hint: bool,
 }
 
 impl Default for Confirm<'static> {
@@ -94,6 +95,14 @@ impl Confirm<'_> {
     /// The default is to append the default value to the prompt to tell the user.
     pub fn show_default(mut self, val: bool) -> Self {
         self.show_default = val;
+        self
+    }
+
+    /// Disables or enables the hint display (e.g. `[y/n]`).
+    ///
+    /// The default is to show the hint.
+    pub fn show_hint(mut self, val: bool) -> Self {
+        self.show_hint = val;
         self
     }
 
@@ -163,7 +172,12 @@ impl Confirm<'_> {
             None
         };
 
-        render.confirm_prompt(&self.prompt, default_if_show)?;
+        term.clear_line()?;
+        if self.show_hint {
+            render.confirm_prompt(&self.prompt, default_if_show)?;
+        } else {
+            term.write_str(&format!("{} ", &self.prompt))?;
+        }
 
         term.hide_cursor()?;
         term.flush()?;
@@ -260,6 +274,7 @@ impl<'a> Confirm<'a> {
             show_default: true,
             wait_for_newline: false,
             theme,
+            show_hint: true,
         }
     }
 }

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -172,11 +172,10 @@ impl Confirm<'_> {
             None
         };
 
-        term.clear_line()?;
         if self.show_hint {
             render.confirm_prompt(&self.prompt, default_if_show)?;
         } else {
-            term.write_str(&format!("{} ", &self.prompt))?;
+            render.confirm_prompt_no_hint(&self.prompt)?;
         }
 
         term.hide_cursor()?;

--- a/src/theme/colorful.rs
+++ b/src/theme/colorful.rs
@@ -172,7 +172,6 @@ impl Theme for ColorfulTheme {
             ),
         }
     }
-
     /// Formats a confirm prompt after selection.
     fn format_confirm_prompt_selection(
         &self,

--- a/src/theme/colorful.rs
+++ b/src/theme/colorful.rs
@@ -172,6 +172,21 @@ impl Theme for ColorfulTheme {
             ),
         }
     }
+
+    /// Formats an input prompt without a hint.
+    fn format_confirm_prompt_no_hint(&self, f: &mut dyn fmt::Write, prompt: &str) -> fmt::Result {
+        if !prompt.is_empty() {
+            write!(
+                f,
+                "{} {} {}",
+                &self.prompt_prefix,
+                self.prompt_style.apply_to(prompt),
+                &self.prompt_suffix
+            )?;
+        }
+        Ok(())
+    }
+
     /// Formats a confirm prompt after selection.
     fn format_confirm_prompt_selection(
         &self,

--- a/src/theme/colorful.rs
+++ b/src/theme/colorful.rs
@@ -173,7 +173,7 @@ impl Theme for ColorfulTheme {
         }
     }
 
-    /// Formats an input prompt without a hint.
+    /// Formats a confirm prompt without the hint ([y/n]).
     fn format_confirm_prompt_no_hint(&self, f: &mut dyn fmt::Write, prompt: &str) -> fmt::Result {
         if !prompt.is_empty() {
             write!(

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -45,7 +45,7 @@ pub trait Theme {
         Ok(())
     }
 
-    /// Formats a confirm prompt without a hint.
+    /// Formats a confirm prompt without the hint ([y/n]).
     fn format_confirm_prompt_no_hint(&self, f: &mut dyn fmt::Write, prompt: &str) -> fmt::Result {
         if !prompt.is_empty() {
             write!(f, "{} ", prompt)?;

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -45,6 +45,14 @@ pub trait Theme {
         Ok(())
     }
 
+    /// Formats a confirm prompt without a hint.
+    fn format_confirm_prompt_no_hint(&self, f: &mut dyn fmt::Write, prompt: &str) -> fmt::Result {
+        if !prompt.is_empty() {
+            write!(f, "{} ", prompt)?;
+        }
+        Ok(())
+    }
+
     /// Formats a confirm prompt after selection.
     fn format_confirm_prompt_selection(
         &self,

--- a/src/theme/render.rs
+++ b/src/theme/render.rs
@@ -91,6 +91,10 @@ impl<'a> TermThemeRenderer<'a> {
         self.write_formatted_str(|this, buf| this.theme.format_confirm_prompt(buf, prompt, default))
     }
 
+    pub fn confirm_prompt_no_hint(&mut self, prompt: &str) -> Result<usize> {
+        self.write_formatted_str(|this, buf| this.theme.format_confirm_prompt_no_hint(buf, prompt))
+    }
+
     pub fn confirm_prompt_selection(&mut self, prompt: &str, sel: Option<bool>) -> Result {
         self.write_formatted_prompt(|this, buf| {
             this.theme.format_confirm_prompt_selection(buf, prompt, sel)


### PR DESCRIPTION
Adds a `show_hint` builder method to `Confirm` that allows hiding the `[y/n]` hint and prompt suffix. This is useful for simple "press enter to continue" use cases where the hint is noise.

**Usage:**
```rust
Confirm::new()
    .with_prompt("Press enter to continue")
    .show_hint(false)
    .default(true)
    .interact()
    .unwrap();
```

**Changes:**

Added `show_hint` builder method to Confirm that allows hiding the [y/n] hint. Implemented via a new `format_confirm_prompt_no_hint` trait method with a default implementation

--- 
Resolves #344