### PR TITLE
Fix line length in Select when line has ASCII colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+/rustfmt.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 target
-/rustfmt.toml

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -266,15 +266,11 @@ impl MultiSelect<'_> {
                             % (self.items.len() as i64)) as usize;
                     }
                 }
-                Key::ArrowLeft | Key::Char('h') => {
-                    if paging.active {
-                        sel = paging.previous_page();
-                    }
+                Key::ArrowLeft | Key::Char('h') if paging.active => {
+                    sel = paging.previous_page();
                 }
-                Key::ArrowRight | Key::Char('l') => {
-                    if paging.active {
-                        sel = paging.next_page();
-                    }
+                Key::ArrowRight | Key::Char('l') if paging.active => {
+                    sel = paging.next_page();
                 }
                 Key::Char(' ') => {
                     checked[sel] = !checked[sel];
@@ -286,19 +282,17 @@ impl MultiSelect<'_> {
                         checked.fill(true);
                     }
                 }
-                Key::Escape | Key::Char('q') => {
-                    if allow_quit {
-                        if self.clear {
-                            render.clear()?;
-                        } else {
-                            term.clear_last_lines(paging.capacity)?;
-                        }
-
-                        term.show_cursor()?;
-                        term.flush()?;
-
-                        return Ok(None);
+                Key::Escape | Key::Char('q') if allow_quit => {
+                    if self.clear {
+                        render.clear()?;
+                    } else {
+                        term.clear_last_lines(paging.capacity)?;
                     }
+
+                    term.show_cursor()?;
+                    term.flush()?;
+
+                    return Ok(None);
                 }
                 Key::Enter => {
                     if self.clear {

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -214,8 +214,8 @@ impl Select<'_> {
             .flat_map(|i| i.split('\n'))
             .collect::<Vec<_>>()
         {
-            let size = &items.len_visible();
-            size_vec.push(*size);
+            let size = console::measure_text_width(items);
+            size_vec.push(size);
         }
 
         term.hide_cursor()?;
@@ -334,34 +334,6 @@ impl<'a> Select<'a> {
             max_length: None,
             theme,
         }
-    }
-}
-
-trait VisibleLength {
-    fn len_visible(&self) -> usize;
-}
-
-impl VisibleLength for &str {
-    fn len_visible(&self) -> usize {
-        let mut len: usize = 0;
-
-        let mut chars = self.chars();
-        while let Some(c) = chars.next() {
-            if c == '\x1b' {
-                #[allow(clippy::while_let_on_iterator)]
-                while let Some(c) = chars.next() {
-                    if c == 'm' {
-                        break;
-                    }
-                }
-
-                continue;
-            }
-
-            len += 1;
-        }
-
-        len
     }
 }
 

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -214,7 +214,7 @@ impl Select<'_> {
             .flat_map(|i| i.split('\n'))
             .collect::<Vec<_>>()
         {
-            let size = &items.len();
+            let size = &items.len_visible();
             size_vec.push(*size);
         }
 
@@ -334,6 +334,34 @@ impl<'a> Select<'a> {
             max_length: None,
             theme,
         }
+    }
+}
+
+trait VisibleLength {
+    fn len_visible(&self) -> usize;
+}
+
+impl VisibleLength for &str {
+    fn len_visible(&self) -> usize {
+        let mut len: usize = 0;
+
+        let mut chars = self.chars();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                #[allow(clippy::while_let_on_iterator)]
+                while let Some(c) = chars.next() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+
+                continue;
+            }
+
+            len += 1;
+        }
+
+        len
     }
 }
 

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -246,19 +246,17 @@ impl Select<'_> {
                         sel = (sel as u64 + 1).rem(self.items.len() as u64) as usize;
                     }
                 }
-                Key::Escape | Key::Char('q') => {
-                    if allow_quit {
-                        if self.clear {
-                            render.clear()?;
-                        } else {
-                            term.clear_last_lines(paging.capacity)?;
-                        }
-
-                        term.show_cursor()?;
-                        term.flush()?;
-
-                        return Ok(None);
+                Key::Escape | Key::Char('q') if allow_quit => {
+                    if self.clear {
+                        render.clear()?;
+                    } else {
+                        term.clear_last_lines(paging.capacity)?;
                     }
+
+                    term.show_cursor()?;
+                    term.flush()?;
+
+                    return Ok(None);
                 }
                 Key::ArrowUp | Key::BackTab | Key::Char('k') => {
                     if sel == !0 {
@@ -268,15 +266,11 @@ impl Select<'_> {
                             % (self.items.len() as i64)) as usize;
                     }
                 }
-                Key::ArrowLeft | Key::Char('h') => {
-                    if paging.active {
-                        sel = paging.previous_page();
-                    }
+                Key::ArrowLeft | Key::Char('h') if paging.active => {
+                    sel = paging.previous_page();
                 }
-                Key::ArrowRight | Key::Char('l') => {
-                    if paging.active {
-                        sel = paging.next_page();
-                    }
+                Key::ArrowRight | Key::Char('l') if paging.active => {
+                    sel = paging.next_page();
                 }
 
                 Key::Enter | Key::Char(' ') if sel != !0 => {

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -244,66 +244,60 @@ impl Sort<'_> {
                         order.swap(old_sel, sel);
                     }
                 }
-                Key::ArrowLeft | Key::Char('h') => {
-                    if paging.active {
-                        let old_sel = sel;
-                        let old_page = paging.current_page;
+                Key::ArrowLeft | Key::Char('h') if paging.active => {
+                    let old_sel = sel;
+                    let old_page = paging.current_page;
 
-                        sel = paging.previous_page();
+                    sel = paging.previous_page();
 
-                        if checked {
-                            let indexes: Vec<_> = if old_page == 0 {
-                                let indexes1: Vec<_> = (0..=old_sel).rev().collect();
-                                let indexes2: Vec<_> = (sel..self.items.len()).rev().collect();
-                                [indexes1, indexes2].concat()
-                            } else {
-                                (sel..=old_sel).rev().collect()
-                            };
+                    if checked {
+                        let indexes: Vec<_> = if old_page == 0 {
+                            let indexes1: Vec<_> = (0..=old_sel).rev().collect();
+                            let indexes2: Vec<_> = (sel..self.items.len()).rev().collect();
+                            [indexes1, indexes2].concat()
+                        } else {
+                            (sel..=old_sel).rev().collect()
+                        };
 
-                            for index in 0..(indexes.len() - 1) {
-                                order.swap(indexes[index], indexes[index + 1]);
-                            }
+                        for index in 0..(indexes.len() - 1) {
+                            order.swap(indexes[index], indexes[index + 1]);
                         }
                     }
                 }
-                Key::ArrowRight | Key::Char('l') => {
-                    if paging.active {
-                        let old_sel = sel;
-                        let old_page = paging.current_page;
+                Key::ArrowRight | Key::Char('l') if paging.active => {
+                    let old_sel = sel;
+                    let old_page = paging.current_page;
 
-                        sel = paging.next_page();
+                    sel = paging.next_page();
 
-                        if checked {
-                            let indexes: Vec<_> = if old_page == paging.pages - 1 {
-                                let indexes1: Vec<_> = (old_sel..self.items.len()).collect();
-                                let indexes2: Vec<_> = vec![0];
-                                [indexes1, indexes2].concat()
-                            } else {
-                                (old_sel..=sel).collect()
-                            };
+                    if checked {
+                        let indexes: Vec<_> = if old_page == paging.pages - 1 {
+                            let indexes1: Vec<_> = (old_sel..self.items.len()).collect();
+                            let indexes2: Vec<_> = vec![0];
+                            [indexes1, indexes2].concat()
+                        } else {
+                            (old_sel..=sel).collect()
+                        };
 
-                            for index in 0..(indexes.len() - 1) {
-                                order.swap(indexes[index], indexes[index + 1]);
-                            }
+                        for index in 0..(indexes.len() - 1) {
+                            order.swap(indexes[index], indexes[index + 1]);
                         }
                     }
                 }
                 Key::Char(' ') => {
                     checked = !checked;
                 }
-                Key::Escape | Key::Char('q') => {
-                    if allow_quit {
-                        if self.clear {
-                            render.clear()?;
-                        } else {
-                            term.clear_last_lines(paging.capacity)?;
-                        }
-
-                        term.show_cursor()?;
-                        term.flush()?;
-
-                        return Ok(None);
+                Key::Escape | Key::Char('q') if allow_quit => {
+                    if self.clear {
+                        render.clear()?;
+                    } else {
+                        term.clear_last_lines(paging.capacity)?;
                     }
+
+                    term.show_cursor()?;
+                    term.flush()?;
+
+                    return Ok(None);
                 }
                 Key::Enter => {
                     if self.clear {


### PR DESCRIPTION
I was trying to use `Select`, but because I have ASCII color codes in my items, it was calculating the line length incorrectly, causing problems with rendering. For example, pressing `Up` would move the entire selection prompt up as well, deleting the line above the prompt.

So, I made a function `len_visible()` on `&str` that calculates the length, excluding the color codes.